### PR TITLE
OpenAPI contract for backend <---> frontend interactions

### DIFF
--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -30,7 +30,7 @@ paths:
         '200':
           description: |
             operation was successful, returns the resultant spec with status "success", or
-            conflicts with status "conflict"
+            conflicts with status "conflicts"
           content:
             application/json:
               schema:

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -7,7 +7,7 @@ servers:
   - description: Spec Math API Server
     url: http://specmath.cloud.google.com/v1
 paths:
-  /specMath/union:
+  /specMath/merge:
     post:
       description: perform a union on two specs, with optional defaults file and conflict resolutions
       operationId: specMathUnion
@@ -17,7 +17,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UnionBody"
+              $ref: "#/components/schemas/MergeBody"
       responses: 
         '200':
           description: operation was successful, returns the resultant spec 
@@ -26,7 +26,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/OperationSuccess"
         '406':
-          description: return information relevant to the merge conflict in case of a failed union
+          description: return information relevant to the conflict in case of a failed union
           content:
             application/json:
               schema:
@@ -35,7 +35,7 @@ paths:
                   conflicts:
                     type: array
                     items:
-                      "$ref": "#/components/schemas/UnionConflictObject"
+                      "$ref": "#/components/schemas/MergeConflictObject"
         default:
           description: error
           content:
@@ -54,7 +54,6 @@ paths:
           application/json:
             schema: 
               "$ref": "#/components/schemas/OverlayBody"
-        
       responses:
         '200':
           description: operation was successful, returns the resultant spec 
@@ -70,7 +69,7 @@ paths:
                 "$ref":  "#/components/schemas/Error"                
 components:
   schemas:
-    UnionBody:
+    MergeBody:
       description: holds data required for the union operation
       type: object
       required:
@@ -87,10 +86,10 @@ components:
           description: an OpenAPI specification fragment which contains metadata about the merged spec
           type: string
         conflictResolutions:
-          description: an array of UnionConflictObjects which specifies resolutions to conflicting keypaths
+          description: an array of MergeConflictObjects which specify resolutions to conflicting keypaths
           type: array
           items:
-            "$ref": "#/components/schemas/UnionConflictObject"
+            "$ref": "#/components/schemas/MergeConflictObject"
     
     OverlayBody:
       description: holds data required for the overlay operation
@@ -106,7 +105,7 @@ components:
           description: an OpenAPI specification fragment which contains metadata about the merged spec
           type: string
 
-    UnionConflictObject:
+    MergeConflictObject:
       description: an individual conflict
       type: object
       properties:

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -11,10 +11,10 @@ paths:
     post:
       description: |
         perform a union on two specs, with optional defaults file and conflict resolutions.
-        The endpoint may return a success, which is the result of a successful union,
-        or a failure, which means some unhandled conflicts occurred in the union. In the latter case,
-        a 406 code will be sent along with an array of conflict objects. The user now has two ways
-        to resolve the conflicts. First, they may iterate through the conflicts and add a value to the
+        The endpoint may return a "success" status code along with the merged spec, which is the
+        result of a successful union, or a "conflicts" code, which means some unhandled conflicts occurred
+        in the union. In the latter case, an array of conflict objects will be sent. The user now has two
+        ways to resolve the conflicts. First, they may iterate through the conflicts and add a value to the
         resolvedValue property based on the options available. They could also manually resolve the
         conflicts in the original YAML files. In either case, they can send another request to this
         endpoint with the conflicts resolved.
@@ -88,7 +88,7 @@ components:
           description: an OpenAPI specification fragment which contains metadata about the merged spec
           type: string
         conflictResolutions:
-          description: an array of MergeConflict which specify resolutions to conflicting keypaths
+          description: an array of MergeConflict objects which specify resolutions to conflicting keypaths
           type: array
           items:
             "$ref": "#/components/schemas/MergeConflict"
@@ -134,7 +134,7 @@ components:
           description: the result of the operation, an OpenAPI specification
           type: string
         conflicts:
-            description: an array of MergeConflict which specify resolutions to conflicting keypaths
+            description: an array of MergeConflict objects which specify resolutions to conflicting keypaths
             type: array
             items:
               "$ref": "#/components/schemas/MergeConflict"

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -2,41 +2,31 @@ openapi: 3.0.0
 info: 
   title: Spec Math API Server
   version: 1.0.0
-  description: An API that exposes some operations from the Spec Math Library.
+  description: An API that exposes some operations from the Spec Math Library
 servers:
   - description: Spec Math API Server
     url: http://specmath.cloud.google.com/v1
 paths:
-  /specMath:
+  /specMath/union:
     post:
-      operationId: specMath
-      description: main endpoint for performing Spec Math operations relevant to the UI.
-      parameters:
-        - name: operation
-          description: the operation (union)
-          in: query
-          required: true
-          schema:
-            type: string
-            example: union
+      description: perform a union on two specs, with optional defaults file and conflict resolutions
+      operationId: specMathUnion
       requestBody:
-        description: data needed for the spec math operation provided in the query
+        description: data needed for the union operation
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/specMathBody"
+              $ref: "#/components/schemas/UnionBody"
       responses: 
         '200':
-          description: operation was successful, return the merged spec 
+          description: operation was successful, returns the resultant spec 
           content:
             application/json:
               schema:
-                properties:
-                  result:
-                    type: string
+                "$ref": "#/components/schemas/OperationSuccess"
         '406':
-          description: return information relevant to the merge conflict in case of a failed union.
+          description: return information relevant to the merge conflict in case of a failed union
           content:
             application/json:
               schema:
@@ -45,27 +35,78 @@ paths:
                   conflicts:
                     type: array
                     items:
-                      "$ref":  "#/components/schemas/conflictObject"
-                  
+                      "$ref": "#/components/schemas/UnionConflictObject"
+        default:
+          description: error
+          content:
+            application/json:
+              schema:
+                "$ref":  "#/components/schemas/Error"  
+
+  /specMath/overlay:
+    post:
+      description: perform an overlay on a spec
+      operationId: specMathOverlay
+      requestBody:
+        description: data needed for the overlay operation
+        required: true
+        content: 
+          application/json:
+            schema: 
+              "$ref": "#/components/schemas/OverlayBody"
+        
+      responses:
+        '200':
+          description: operation was successful, returns the resultant spec 
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OperationSuccess"   
+        default:
+          description: error
+          content:
+            application/json:
+              schema:
+                "$ref":  "#/components/schemas/Error"                
 components:
   schemas:
-    specMathBody:
-      description: holds data required for the operation
+    UnionBody:
+      description: holds data required for the union operation
       type: object
-      required: 
-        - specs
-        - operation
+      required:
+        - spec1
+        - spec2
       properties:
         spec1:
+          description: an OpenAPI specification
           type: string
         spec2:
+          description: an OpenAPI specification
           type: string
-        conflicts:
+        defaults:
+          description: an OpenAPI specification fragment which contains metadata about the merged spec
+          type: string
+        conflictResolutions:
+          description: an array of UnionConflictObjects which specifies resolutions to conflicting keypaths
           type: array
           items:
-            "$ref": "#/components/schemas/conflictObject"
+            "$ref": "#/components/schemas/UnionConflictObject"
+    
+    OverlayBody:
+      description: holds data required for the overlay operation
+      type: object
+      required:
+        - spec
+        - overlay
+      properties:
+        spec:
+          description: an OpenAPI specification
+          type: string
+        overlay:
+          description: an OpenAPI specification fragment which contains metadata about the merged spec
+          type: string
 
-    conflictObject:
+    UnionConflictObject:
       description: an individual conflict
       type: object
       properties:
@@ -81,4 +122,24 @@ components:
         resolvedValue:
           type: string
           example: Post a single pet
+    
+    OperationSuccess:
+      description: a successful operation result
+      type: object
+      properties:
+        result:
+          description: the result of the operation, an OpenAPI specification
+          type: string
+    
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
             

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -132,6 +132,7 @@ components:
           type: string
     
     Error:
+      description: generic error object
       type: object
       required:
         - code

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -28,22 +28,24 @@ paths:
               $ref: "#/components/schemas/MergeBody"
       responses: 
         '200':
-          description: operation was successful, returns the resultant spec 
+          description: |
+          operation was successful, returns the resultant spec with status "success", or
+          conflicts with status "conflict"
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/OperationSuccess"
-        '406':
-          description: return information relevant to the conflict in case of a failed union
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  conflicts:
-                    type: array
-                    items:
-                      "$ref": "#/components/schemas/MergeConflictObject"
+#        '400':
+#          description: return information relevant to the conflict in case of a failed union
+#          content:
+#            application/json:
+#              schema:
+#                type: object
+#                properties:
+#                  conflicts:
+#                    type: array
+#                    items:
+#                      "$ref": "#/components/schemas/MergeConflictObject"
         default:
           description: error
           content:
@@ -133,13 +135,18 @@ components:
           type: string
           example: Post a single pet
     
-    OperationSuccess:
-      description: a successful operation result
+    MergeOperationResult:
+      description: the result of the merge operation
       type: object
       properties:
         result:
           description: the result of the operation, an OpenAPI specification
           type: string
+      conflicts:
+          description: an array of MergeConflictObjects which specify resolutions to conflicting keypaths
+        type: array
+        items:
+          "$ref": "#/components/schemas/MergeConflictObject"
     
     Error:
       description: generic error object

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -143,4 +143,4 @@ components:
           format: int32
         message:
           type: string
-            
+

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -125,7 +125,7 @@ components:
           example: Post a single pet
     
     OperationResponse:
-      description: the result of a 200 response
+      description: the result of a 200 response on an operations/ endpoint
       type: object
       required:
         - status

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -1,0 +1,85 @@
+openapi: 3.0.0
+info: 
+  title: Spec Math
+  version: 1.0.0
+paths:
+  /processFiles:
+    post:
+      operationId: processFiles
+      description: Main endpoint for uploading files, processing files and solving merge conflicts
+      requestBody:
+        description: Perform spec math operation
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/processFilesBody"
+      responses: 
+        '200':
+          description: Operation was successful 
+          content:
+            application/json:
+              schema:
+                properties:
+                  result:
+                    type: string
+        '406':
+          description: Merge conflicts detected
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/conflictResponse"
+                
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: array        
+                
+components:
+  schemas:
+    processFilesBody:
+      type: object
+      required: 
+        - specs
+        - operation
+      properties:
+        specs:
+          type: array
+        conflicts:
+          type: array
+          items:
+            "$ref": "#/components/schemas/conflictObject"
+        defaultsFile:
+          type: string
+        filterFile:
+          type: string
+        operation:
+          type: string
+          
+
+    conflictResponse:
+      type: object
+      properties:
+        conflicts:
+          type: array
+          items:
+            "$ref":  "#/components/schemas/conflictObject"
+
+    conflictObject:
+      type: object
+      properties:
+        keypath:
+          type: string
+          example: "paths:/pet:post:summary"
+        optionA:
+          type: string
+          example: "Post a single pet"
+        optionB:
+          type: string
+          example: "Post several pets"
+        resolvedValue:
+          type: string
+          example: "Post pets"
+            

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -9,7 +9,15 @@ servers:
 paths:
   /specMath/merge:
     post:
-      description: perform a union on two specs, with optional defaults file and conflict resolutions
+      description: |
+      perform a union on two specs, with optional defaults file and conflict resolutions.
+      The endpoint may return a success, which is the result of a successful union,
+      or a failure, which means some unhandled conflicts occurred in the union. In the latter case,
+      a 406 code will be sent along with an array of conflict objects. The user now has two ways
+      to resolve the conflicts. First, they may iterate through the conflicts and add a value to the
+      resolvedValue property based on the options available. They could also manually resolve the
+      conflicts in the original YAML files. In either case, they can send another request to this
+      endpoint with the conflicts resolved.
       operationId: specMathUnion
       requestBody:
         description: data needed for the union operation
@@ -45,7 +53,10 @@ paths:
 
   /specMath/overlay:
     post:
-      description: perform an overlay on a spec
+      description: |
+        the overlay endpoint takes a spec and an overlay file (which is a partial spec)
+        and performs a specialized union where the overlay takes priority. In case of a collision, a
+        conflict will not be reported and the value from the overlay will be taken.
       operationId: specMathOverlay
       requestBody:
         description: data needed for the overlay operation

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -1,22 +1,34 @@
 openapi: 3.0.0
 info: 
-  title: Spec Math
+  title: Spec Math API Server
   version: 1.0.0
+  description: An API that exposes some operations from the Spec Math Library.
+servers:
+  - description: Spec Math API Server
+    url: http://specmath.cloud.google.com/v1
 paths:
-  /processFiles:
+  /specMath:
     post:
-      operationId: processFiles
-      description: Main endpoint for uploading files, processing files and solving merge conflicts
+      operationId: specMath
+      description: main endpoint for performing Spec Math operations relevant to the UI.
+      parameters:
+        - name: operation
+          description: the operation (union)
+          in: query
+          required: true
+          schema:
+            type: string
+            example: union
       requestBody:
-        description: Perform spec math operation
+        description: data needed for the spec math operation provided in the query
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/processFilesBody"
+              $ref: "#/components/schemas/specMathBody"
       responses: 
         '200':
-          description: Operation was successful 
+          description: operation was successful, return the merged spec 
           content:
             application/json:
               schema:
@@ -24,62 +36,49 @@ paths:
                   result:
                     type: string
         '406':
-          description: Merge conflicts detected
+          description: return information relevant to the merge conflict in case of a failed union.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/conflictResponse"
-                
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                type: array        
-                
+                type: object
+                properties:
+                  conflicts:
+                    type: array
+                    items:
+                      "$ref":  "#/components/schemas/conflictObject"
+                  
 components:
   schemas:
-    processFilesBody:
+    specMathBody:
+      description: holds data required for the operation
       type: object
       required: 
         - specs
         - operation
       properties:
-        specs:
-          type: array
+        spec1:
+          type: string
+        spec2:
+          type: string
         conflicts:
           type: array
           items:
             "$ref": "#/components/schemas/conflictObject"
-        defaultsFile:
-          type: string
-        filterFile:
-          type: string
-        operation:
-          type: string
-          
-
-    conflictResponse:
-      type: object
-      properties:
-        conflicts:
-          type: array
-          items:
-            "$ref":  "#/components/schemas/conflictObject"
 
     conflictObject:
+      description: an individual conflict
       type: object
       properties:
         keypath:
           type: string
-          example: "paths:/pet:post:summary"
-        optionA:
+          example: paths:/pet:post:summary
+        option1:
           type: string
-          example: "Post a single pet"
-        optionB:
+          example: Post a single pet
+        option2:
           type: string
-          example: "Post several pets"
+          example: Post several pets
         resolvedValue:
           type: string
-          example: "Post pets"
+          example: Post a single pet
             

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -7,45 +7,34 @@ servers:
   - description: Spec Math API Server
     url: http://specmath.cloud.google.com/v1
 paths:
-  /specMath/merge:
+  /operations/merge:
     post:
       description: |
-      perform a union on two specs, with optional defaults file and conflict resolutions.
-      The endpoint may return a success, which is the result of a successful union,
-      or a failure, which means some unhandled conflicts occurred in the union. In the latter case,
-      a 406 code will be sent along with an array of conflict objects. The user now has two ways
-      to resolve the conflicts. First, they may iterate through the conflicts and add a value to the
-      resolvedValue property based on the options available. They could also manually resolve the
-      conflicts in the original YAML files. In either case, they can send another request to this
-      endpoint with the conflicts resolved.
-      operationId: specMathUnion
+        perform a union on two specs, with optional defaults file and conflict resolutions.
+        The endpoint may return a success, which is the result of a successful union,
+        or a failure, which means some unhandled conflicts occurred in the union. In the latter case,
+        a 406 code will be sent along with an array of conflict objects. The user now has two ways
+        to resolve the conflicts. First, they may iterate through the conflicts and add a value to the
+        resolvedValue property based on the options available. They could also manually resolve the
+        conflicts in the original YAML files. In either case, they can send another request to this
+        endpoint with the conflicts resolved.
+      operationId: union
       requestBody:
         description: data needed for the union operation
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MergeBody"
+              $ref: "#/components/schemas/MergeRequest"
       responses: 
         '200':
           description: |
-          operation was successful, returns the resultant spec with status "success", or
-          conflicts with status "conflict"
+            operation was successful, returns the resultant spec with status "success", or
+            conflicts with status "conflict"
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/OperationSuccess"
-#        '400':
-#          description: return information relevant to the conflict in case of a failed union
-#          content:
-#            application/json:
-#              schema:
-#                type: object
-#                properties:
-#                  conflicts:
-#                    type: array
-#                    items:
-#                      "$ref": "#/components/schemas/MergeConflictObject"
+                "$ref": "#/components/schemas/Success"
         default:
           description: error
           content:
@@ -53,27 +42,27 @@ paths:
               schema:
                 "$ref":  "#/components/schemas/Error"  
 
-  /specMath/overlay:
+  /operations/overlay:
     post:
       description: |
         the overlay endpoint takes a spec and an overlay file (which is a partial spec)
         and performs a specialized union where the overlay takes priority. In case of a collision, a
         conflict will not be reported and the value from the overlay will be taken.
-      operationId: specMathOverlay
+      operationId: overlay
       requestBody:
         description: data needed for the overlay operation
         required: true
         content: 
           application/json:
             schema: 
-              "$ref": "#/components/schemas/OverlayBody"
+              "$ref": "#/components/schemas/OverlayRequest"
       responses:
         '200':
           description: operation was successful, returns the resultant spec 
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/OperationSuccess"   
+                "$ref": "#/components/schemas/Success"   
         default:
           description: error
           content:
@@ -82,7 +71,7 @@ paths:
                 "$ref":  "#/components/schemas/Error"                
 components:
   schemas:
-    MergeBody:
+    MergeRequest:
       description: holds data required for the union operation
       type: object
       required:
@@ -99,12 +88,12 @@ components:
           description: an OpenAPI specification fragment which contains metadata about the merged spec
           type: string
         conflictResolutions:
-          description: an array of MergeConflictObjects which specify resolutions to conflicting keypaths
+          description: an array of MergeConflict which specify resolutions to conflicting keypaths
           type: array
           items:
-            "$ref": "#/components/schemas/MergeConflictObject"
+            "$ref": "#/components/schemas/MergeConflict"
     
-    OverlayBody:
+    OverlayRequest:
       description: holds data required for the overlay operation
       type: object
       required:
@@ -118,7 +107,7 @@ components:
           description: an OpenAPI specification fragment which contains metadata about the merged spec
           type: string
 
-    MergeConflictObject:
+    MergeConflict:
       description: an individual conflict
       type: object
       properties:
@@ -135,19 +124,25 @@ components:
           type: string
           example: Post a single pet
     
-    MergeOperationResult:
-      description: the result of the merge operation
+    Success:
+      description: the result of a 200 response
       type: object
+      required:
+        - status
       properties:
         result:
           description: the result of the operation, an OpenAPI specification
           type: string
-      conflicts:
-          description: an array of MergeConflictObjects which specify resolutions to conflicting keypaths
-        type: array
-        items:
-          "$ref": "#/components/schemas/MergeConflictObject"
-    
+        conflicts:
+            description: an array of MergeConflict which specify resolutions to conflicting keypaths
+            type: array
+            items:
+              "$ref": "#/components/schemas/MergeConflict"
+        status: 
+          description: describes whether the operation was successful or not, or the presence of merge conflicts
+          type: string
+          example: success | conflicts | operation error
+
     Error:
       description: generic error object
       type: object

--- a/docs/contract.yaml
+++ b/docs/contract.yaml
@@ -124,7 +124,7 @@ components:
           type: string
           example: Post a single pet
     
-    Success:
+    OperationResponse:
       description: the result of a 200 response
       type: object
       required:


### PR DESCRIPTION
- [x] Omar and Rafi worked to create a contract to be used for backend <---> frontend interactions
- [x] currently has two endpoints for merging and overlaying. Can be expanded as needed

Question:
we iterated on the following ways to do the endpoints:
- singular endpoint for all spec math operations, specific operation (union, overlay, etc..) is provided in query parameter, and requestBody is generalized for all endpoints. That would mean that properties are optional and used based on the request. An example call would then be to the path /v1/specMath/?operation=union.
- same as above, but with operation provided as a property in the requestBody. An example call: /v1/specMath/
- one endpoint for EACH spec math operation. No query parameter is required, and each requestBody has information specific to the operation. This stricter approach may be more helpful for validation and setting required properties for each endpoint. An example call: /v1/specMath/merge or /v1/specMath/overlay

We ultimately decided on the latter approach and wanted to know your thoughts. That is the approach in this PR.
