### PR TITLE
[Library Supports Union -- PR 3] Serialization functions 

### DIFF
--- a/library/src/main/java/SpecTreeToYamlStringConverter.java
+++ b/library/src/main/java/SpecTreeToYamlStringConverter.java
@@ -21,11 +21,7 @@ import java.util.Map;
 /** Provides the ability to serialize Spec Trees represented as LinkedHashMaps into YAML strings */
 public class SpecTreeToYamlStringConverter {
 
-  int indent;
-
-  public SpecTreeToYamlStringConverter() {
-    this.indent = 2;
-  }
+  public static final int SPACES_TO_INDENT = 2;
 
   /**
    * Serializes a spec tree represented as a {@code LinkedHashMap} into a YAML string.
@@ -33,7 +29,7 @@ public class SpecTreeToYamlStringConverter {
    * @param yamlMap a spec tree which is a LinkedHashMap with String keys and Object values
    * @return a YAML string which represents the serialization of {@code yamlMap} as a YAML string
    */
-  public String convertSpecTreeToYamlString(LinkedHashMap<String, Object> yamlMap)
+  public static String convertSpecTreeToYamlString(LinkedHashMap<String, Object> yamlMap)
       throws UnexpectedTypeException {
     return convertSpecTreeToYamlString(yamlMap, 0, false);
   }
@@ -48,7 +44,7 @@ public class SpecTreeToYamlStringConverter {
    *     the first element of a list, which needs to be processed in a special way
    * @return a YAML string which represents the serialization of {@code yamlMap} as a YAML string
    */
-  private String convertSpecTreeToYamlString(
+  private static String convertSpecTreeToYamlString(
       LinkedHashMap<String, Object> yamlMap, int level, boolean firstListElement)
       throws UnexpectedTypeException {
     StringBuilder str = new StringBuilder();
@@ -84,7 +80,7 @@ public class SpecTreeToYamlStringConverter {
    * @param str the StringBuilder which we append to during the traversal
    * @return {@code false} if {@code firstListElement} was initially true. Otherwise it returns true
    */
-  private boolean handleFirstListElementSpacing(
+  private static boolean handleFirstListElementSpacing(
       int level, boolean firstListElement, StringBuilder str) {
     if (!firstListElement) {
       str.append(spaces(level));
@@ -101,7 +97,7 @@ public class SpecTreeToYamlStringConverter {
    * @param key the key which we want to append to the StringBuilder, which is handled in special
    *     ways depending on the key
    */
-  private void handleKey(StringBuilder str, String key) {
+  private static void handleKey(StringBuilder str, String key) {
     if ((key.chars().allMatch(Character::isDigit))) {
       // the key is a digit, which should be  surrounded by single quotes
       str.append(String.format("'%s':", key));
@@ -118,7 +114,7 @@ public class SpecTreeToYamlStringConverter {
    *     certain keys
    * @param value the primitive value to add to the StringBuilder
    */
-  private void handlePrimitiveValue(StringBuilder str, String key, Object value) {
+  private static void handlePrimitiveValue(StringBuilder str, String key, Object value) {
     if (key.equals("$ref")) {
       // a "$ref" tag should be handled in a special way, with the value in double quotes.
       str.append(String.format(" \"%s\"\n", value));
@@ -134,7 +130,8 @@ public class SpecTreeToYamlStringConverter {
    * @param str the StringBuilder which we append to during the traversal
    * @param value the map value to process further
    */
-  private void handleMapValue(int level, StringBuilder str, LinkedHashMap<String, Object> value)
+  private static void handleMapValue(
+      int level, StringBuilder str, LinkedHashMap<String, Object> value)
       throws UnexpectedTypeException {
     LinkedHashMap<String, Object> valueMap = value;
 
@@ -149,7 +146,7 @@ public class SpecTreeToYamlStringConverter {
    * @param str the StringBuilder which we append to during the traversal
    * @param value the list of values to process
    */
-  private void handleListValues(int level, StringBuilder str, List<Object> value)
+  private static void handleListValues(int level, StringBuilder str, List<Object> value)
       throws UnexpectedTypeException {
     int listLevel = level + 1;
 
@@ -171,80 +168,11 @@ public class SpecTreeToYamlStringConverter {
   }
 
   /** Returns a string with {@code level} * {@code this.indent} spaces. */
-  private String spaces(int level) {
+  private static String spaces(int level) {
     StringBuilder str = new StringBuilder();
-    for (int i = 0; i < level * this.indent; i++) {
+    for (int i = 0; i < level * SPACES_TO_INDENT; i++) {
       str.append(" ");
     }
     return str.toString();
   }
-
-  //  public String convertSpecTreeToYamlString(LinkedHashMap<String, Object> yamlMap)
-  //      throws IOException {
-  //    //The representer allows us to ignore null properties, and to leave off the class
-  // definitions
-  ////    Representer representer = new Representer() {
-  ////      //ignore null properties
-  ////      @Override
-  ////      protected NodeTuple representJavaBeanProperty(Object javaBean, Property property, Object
-  // propertyValue, Tag customTag) {
-  ////        // if value of property is null, ignore it.
-  ////        if (propertyValue == null) {
-  ////          return null;
-  ////        }
-  ////        else {
-  ////          return super.representJavaBeanProperty(javaBean, property, propertyValue,
-  // customTag);
-  ////        }
-  ////      }
-  ////
-  ////      //Don't print the class definition
-  ////      @Override
-  ////      protected MappingNode representJavaBean(Set<Property> properties, Object javaBean) {
-  ////        if (!classTags.containsKey(javaBean.getClass())){
-  ////          addClassTag(javaBean.getClass(), Tag.MAP);
-  ////        }
-  ////
-  ////        return super.representJavaBean(properties, javaBean);
-  ////      }
-  ////    };
-  ////
-  //    DumperOptions options = new DumperOptions();
-  //    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-  //
-  //    YAMLFactory yamlFactory = new YAMLFactory();
-  //
-  //    options.setIndent(4);
-  //    options.setIndicatorIndent(2);
-  //
-  //    StringWriter writer = new StringWriter();
-  //
-  //    Yaml yaml = new Yaml(options);
-  //    yaml.dump(yamlMap, writer);
-  //
-  //    return writer.toString();
-  ////
-  ////    Writer swriter = new StringWriter();
-  ////    yaml.dump(yamlMap, writer);
-  //
-  ////    YamlWriter writer = new YamlWriter(swriter);
-  ////    writer.getConfig().writeConfig.setIndentSize(2);
-  ////    writer.getConfig().writeConfig.setAutoAnchor(false);
-  //////    writer.getConfig().writeConfig.setWriteRootTags(false);
-  //////    writer.getConfig().writeConfig.setWriteDefaultValues(false);
-  ////    writer.getConfig().writeConfig.setKeepBeanPropertyOrder(true);
-  //////    writer.getConfig().writeConfig.setUseVerbatimTags(false);
-  //////    writer.getConfig().writeConfig.setWriteRootElementTags(false);
-  ////    writer.getConfig().writeConfig.setWriteClassname(YamlConfig.WriteClassName.NEVER);
-  //////    writer.getConfig().setClassTag("", LinkedHashMap.class);
-  //////    writer.getConfig().writeConfig.setWriteClassname(YamlConfig.WriteClassName.NEVER);
-  ////
-  ////
-  //////    writer.getConfig().writeConfig.setWriteRootTags(false);
-  //////    writer.getConfig().writeConfig.
-  ////    writer.write(yamlMap);
-  ////
-  ////
-  ////    return swriter.toString();
-  //  }
 }

--- a/library/src/main/java/SpecTreeToYamlStringConverter.java
+++ b/library/src/main/java/SpecTreeToYamlStringConverter.java
@@ -1,0 +1,164 @@
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SpecTreeToYamlStringConverter {
+
+  int indent;
+
+  public SpecTreeToYamlStringConverter() {
+    this.indent = 2;
+  }
+
+  /**
+   * Serializes a spec tree represented as a {@code LinkedHashMap} into a YAML string.
+   *
+   * @param yamlMap a spec tree which is a LinkedHashMap with String keys and Object values
+   * @return a YAML string which represents the serialization of {@code yamlMap} as a YAML string
+   */
+  public String convertSpecTreeToYamlString(LinkedHashMap<String, Object> yamlMap)
+      throws UnexpectedDataException {
+    return convertSpecTreeToYamlString(yamlMap, 0, false);
+  }
+
+  /**
+   * Helper function for Serializing a spec tree represented as a {@code LinkedHashMap} to a YAML
+   * string.
+   *
+   * @param yamlMap a spec tree which is a LinkedHashMap with String keys and Object values
+   * @param level the current traversal level, which influences how many spaces to print out
+   * @param firstListElement a boolean which indicates whether or not current element in the loop is
+   *     the first element of a list, which needs to be processed in a special way
+   * @return a YAML string which represents the serialization of {@code yamlMap} as a YAML string
+   */
+  private String convertSpecTreeToYamlString(
+      LinkedHashMap<String, Object> yamlMap, int level, boolean firstListElement)
+      throws UnexpectedDataException {
+    StringBuilder str = new StringBuilder();
+    for (Map.Entry<String, Object> entry : yamlMap.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+
+      firstListElement = handleFirstListElementSpacing(level, firstListElement, str);
+
+      handleKey(str, key);
+
+      if (TypeChecker.isObjectMap(value)) {
+        handleMapValue(level, str, ObjectCaster.castObjectToStringObjectMap(value));
+      } else if (TypeChecker.isObjectList(value)) {
+        handleListValues(level, str, ObjectCaster.castObjectToListOfObjects(value));
+      } else if (TypeChecker.isObjectPrimitive(value)) {
+        handlePrimitiveValue(str, key, value);
+      } else {
+        throw new UnexpectedDataException("Unexpected Data During Serialization");
+      }
+    }
+
+    return str.toString();
+  }
+
+  /**
+   * Appends spaces according to the {@code level} if the current element is not the first in a
+   * list. Returns the new status of {@code firstListElement}.
+   *
+   * @param level the current traversal level, which influences how many spaces to print out
+   * @param firstListElement a boolean which indicates whether or not current element in the loop is
+   *     the first element of a list, which needs to be processed in a special way
+   * @param str the StringBuilder which we append to during the traversal
+   * @return {@code false} if {@code firstListElement} was initially true. Otherwise it returns true
+   */
+  private boolean handleFirstListElementSpacing(
+      int level, boolean firstListElement, StringBuilder str) {
+    if (!firstListElement) {
+      str.append(spaces(level));
+    } else {
+      firstListElement = false;
+    }
+    return firstListElement;
+  }
+
+  /**
+   * Appends the {@code key} to the StringBuilder.
+   *
+   * @param str the StringBuilder which we append to during the traversal
+   * @param key the key which we want to append to the StringBuilder, which is handled in special
+   *     ways depending on the key
+   */
+  private void handleKey(StringBuilder str, String key) {
+    if ((key.chars().allMatch(Character::isDigit))) {
+      // the key is a digit, which should be  surrounded by single quotes
+      str.append(String.format("'%s':", key));
+    } else {
+      str.append(String.format("%s:", key));
+    }
+  }
+
+  /**
+   * Appends a primitive {@code value} to the StringBuilder.
+   *
+   * @param str the StringBuilder which we append to during the traversal
+   * @param key the key in the map which corresponds to the value, used for special handling of
+   *     certain keys
+   * @param value the primitive value to add to the StringBuilder
+   */
+  private void handlePrimitiveValue(StringBuilder str, String key, Object value) {
+    if (key.equals("$ref")) {
+      // a "$ref" tag should be handled in a special way, with the value in double quotes.
+      str.append(String.format(" \"%s\"\n", value));
+    } else {
+      str.append(String.format(" %s\n", value));
+    }
+  }
+
+  /**
+   * Appends the result of processing a map value to the StringBuilder.
+   *
+   * @param level the current traversal level
+   * @param str the StringBuilder which we append to during the traversal
+   * @param value the map value to process further
+   */
+  private void handleMapValue(int level, StringBuilder str, LinkedHashMap<String, Object> value)
+      throws UnexpectedDataException {
+    LinkedHashMap<String, Object> valueMap = value;
+
+    str.append("\n");
+    str.append(convertSpecTreeToYamlString(valueMap, level + 1, false));
+  }
+
+  /**
+   * Processes and appends the elements in a list to the StringBuilder.
+   *
+   * @param level the current traversal level, which indicates how many spaces to print out
+   * @param str the StringBuilder which we append to during the traversal
+   * @param value the list of values to process
+   */
+  private void handleListValues(int level, StringBuilder str, List<Object> value)
+      throws UnexpectedDataException {
+    int listLevel = level + 1;
+
+    str.append("\n");
+    for (int i = 0; i < value.size(); i++) {
+      str.append(spaces(listLevel));
+      str.append("- ");
+
+      Object element = value.get(i);
+
+      if (TypeChecker.isObjectPrimitive(element)) {
+        str.append(String.format("%s\n", element));
+      } else if (TypeChecker.isObjectMap(element)) {
+        LinkedHashMap<String, Object> elementMap =
+            ObjectCaster.castObjectToStringObjectMap(element);
+        str.append(convertSpecTreeToYamlString(elementMap, listLevel + 1, true));
+      }
+    }
+  }
+
+  /** Returns a string with {@code level} * {@code this.indent} spaces. */
+  private String spaces(int level) {
+    StringBuilder str = new StringBuilder();
+    for (int i = 0; i < level * this.indent; i++) {
+      str.append(" ");
+    }
+    return str.toString();
+  }
+}

--- a/library/src/main/java/SpecTreeToYamlStringConverter.java
+++ b/library/src/main/java/SpecTreeToYamlStringConverter.java
@@ -34,7 +34,7 @@ public class SpecTreeToYamlStringConverter {
    * @return a YAML string which represents the serialization of {@code yamlMap} as a YAML string
    */
   public String convertSpecTreeToYamlString(LinkedHashMap<String, Object> yamlMap)
-      throws UnexpectedDataException {
+      throws UnexpectedTypeException {
     return convertSpecTreeToYamlString(yamlMap, 0, false);
   }
 
@@ -50,7 +50,7 @@ public class SpecTreeToYamlStringConverter {
    */
   private String convertSpecTreeToYamlString(
       LinkedHashMap<String, Object> yamlMap, int level, boolean firstListElement)
-      throws UnexpectedDataException {
+      throws UnexpectedTypeException {
     StringBuilder str = new StringBuilder();
     for (Map.Entry<String, Object> entry : yamlMap.entrySet()) {
       String key = entry.getKey();
@@ -67,7 +67,7 @@ public class SpecTreeToYamlStringConverter {
       } else if (TypeChecker.isObjectPrimitive(value)) {
         handlePrimitiveValue(str, key, value);
       } else {
-        throw new UnexpectedDataException("Unexpected Data During Serialization");
+        throw new UnexpectedTypeException("Unexpected Data During Serialization");
       }
     }
 
@@ -135,7 +135,7 @@ public class SpecTreeToYamlStringConverter {
    * @param value the map value to process further
    */
   private void handleMapValue(int level, StringBuilder str, LinkedHashMap<String, Object> value)
-      throws UnexpectedDataException {
+      throws UnexpectedTypeException {
     LinkedHashMap<String, Object> valueMap = value;
 
     str.append("\n");
@@ -150,7 +150,7 @@ public class SpecTreeToYamlStringConverter {
    * @param value the list of values to process
    */
   private void handleListValues(int level, StringBuilder str, List<Object> value)
-      throws UnexpectedDataException {
+      throws UnexpectedTypeException {
     int listLevel = level + 1;
 
     str.append("\n");

--- a/library/src/main/java/SpecTreeToYamlStringConverter.java
+++ b/library/src/main/java/SpecTreeToYamlStringConverter.java
@@ -1,7 +1,24 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/** Provides the ability to serialize Spec Trees represented as LinkedHashMaps into YAML strings */
 public class SpecTreeToYamlStringConverter {
 
   int indent;
@@ -22,7 +39,7 @@ public class SpecTreeToYamlStringConverter {
   }
 
   /**
-   * Helper function for serializing a spec tree represented as a {@code LinkedHashMap} to a YAML
+   * Helper function for Serializing a spec tree represented as a {@code LinkedHashMap} to a YAML
    * string.
    *
    * @param yamlMap a spec tree which is a LinkedHashMap with String keys and Object values
@@ -161,4 +178,73 @@ public class SpecTreeToYamlStringConverter {
     }
     return str.toString();
   }
+
+  //  public String convertSpecTreeToYamlString(LinkedHashMap<String, Object> yamlMap)
+  //      throws IOException {
+  //    //The representer allows us to ignore null properties, and to leave off the class
+  // definitions
+  ////    Representer representer = new Representer() {
+  ////      //ignore null properties
+  ////      @Override
+  ////      protected NodeTuple representJavaBeanProperty(Object javaBean, Property property, Object
+  // propertyValue, Tag customTag) {
+  ////        // if value of property is null, ignore it.
+  ////        if (propertyValue == null) {
+  ////          return null;
+  ////        }
+  ////        else {
+  ////          return super.representJavaBeanProperty(javaBean, property, propertyValue,
+  // customTag);
+  ////        }
+  ////      }
+  ////
+  ////      //Don't print the class definition
+  ////      @Override
+  ////      protected MappingNode representJavaBean(Set<Property> properties, Object javaBean) {
+  ////        if (!classTags.containsKey(javaBean.getClass())){
+  ////          addClassTag(javaBean.getClass(), Tag.MAP);
+  ////        }
+  ////
+  ////        return super.representJavaBean(properties, javaBean);
+  ////      }
+  ////    };
+  ////
+  //    DumperOptions options = new DumperOptions();
+  //    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+  //
+  //    YAMLFactory yamlFactory = new YAMLFactory();
+  //
+  //    options.setIndent(4);
+  //    options.setIndicatorIndent(2);
+  //
+  //    StringWriter writer = new StringWriter();
+  //
+  //    Yaml yaml = new Yaml(options);
+  //    yaml.dump(yamlMap, writer);
+  //
+  //    return writer.toString();
+  ////
+  ////    Writer swriter = new StringWriter();
+  ////    yaml.dump(yamlMap, writer);
+  //
+  ////    YamlWriter writer = new YamlWriter(swriter);
+  ////    writer.getConfig().writeConfig.setIndentSize(2);
+  ////    writer.getConfig().writeConfig.setAutoAnchor(false);
+  //////    writer.getConfig().writeConfig.setWriteRootTags(false);
+  //////    writer.getConfig().writeConfig.setWriteDefaultValues(false);
+  ////    writer.getConfig().writeConfig.setKeepBeanPropertyOrder(true);
+  //////    writer.getConfig().writeConfig.setUseVerbatimTags(false);
+  //////    writer.getConfig().writeConfig.setWriteRootElementTags(false);
+  ////    writer.getConfig().writeConfig.setWriteClassname(YamlConfig.WriteClassName.NEVER);
+  //////    writer.getConfig().setClassTag("", LinkedHashMap.class);
+  //////    writer.getConfig().writeConfig.setWriteClassname(YamlConfig.WriteClassName.NEVER);
+  ////
+  ////
+  //////    writer.getConfig().writeConfig.setWriteRootTags(false);
+  //////    writer.getConfig().writeConfig.
+  ////    writer.write(yamlMap);
+  ////
+  ////
+  ////    return swriter.toString();
+  //  }
 }

--- a/library/src/main/java/SpecTreeToYamlStringConverter.java
+++ b/library/src/main/java/SpecTreeToYamlStringConverter.java
@@ -22,7 +22,7 @@ public class SpecTreeToYamlStringConverter {
   }
 
   /**
-   * Helper function for Serializing a spec tree represented as a {@code LinkedHashMap} to a YAML
+   * Helper function for serializing a spec tree represented as a {@code LinkedHashMap} to a YAML
    * string.
    *
    * @param yamlMap a spec tree which is a LinkedHashMap with String keys and Object values

--- a/library/src/main/java/UnexpectedDataException.java
+++ b/library/src/main/java/UnexpectedDataException.java
@@ -1,0 +1,5 @@
+public class UnexpectedDataException extends Exception {
+  public UnexpectedDataException(String message) {
+    super(message);
+  }
+}

--- a/library/src/main/java/UnexpectedDataException.java
+++ b/library/src/main/java/UnexpectedDataException.java
@@ -1,3 +1,20 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/** An exception thrown when there was unexpected data when performing an operation */
 public class UnexpectedDataException extends Exception {
   public UnexpectedDataException(String message) {
     super(message);

--- a/library/src/main/java/UnexpectedTypeException.java
+++ b/library/src/main/java/UnexpectedTypeException.java
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 /** An exception thrown when there was unexpected data when performing an operation */
-public class UnexpectedDataException extends Exception {
-  public UnexpectedDataException(String message) {
+public class UnexpectedTypeException extends Exception {
+  public UnexpectedTypeException(String message) {
     super(message);
   }
 }

--- a/library/src/test/java/SpecTreeToYamlStringConverterTest.java
+++ b/library/src/test/java/SpecTreeToYamlStringConverterTest.java
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -9,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 class SpecTreeToYamlStringConverterTest {
   @Test
-  void testConvertMapToYamlString() throws IOException, UnexpectedDataException {
+  void testConvertMapToYamlString() throws IOException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/serializationSample.yaml");
@@ -29,7 +45,7 @@ class SpecTreeToYamlStringConverterTest {
     var specTreeToYamlStringsConverter = new SpecTreeToYamlStringConverter();
 
     assertThrows(
-        UnexpectedDataException.class,
+        UnexpectedTypeException.class,
         () -> specTreeToYamlStringsConverter.convertSpecTreeToYamlString(map1));
   }
 }

--- a/library/src/test/java/SpecTreeToYamlStringConverterTest.java
+++ b/library/src/test/java/SpecTreeToYamlStringConverterTest.java
@@ -30,9 +30,7 @@ class SpecTreeToYamlStringConverterTest {
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/serializationSample.yaml");
 
-    var specTreeToYamlStringsConverter = new SpecTreeToYamlStringConverter();
-
-    assertThat(specTreeToYamlStringsConverter.convertSpecTreeToYamlString(map1))
+    assertThat(SpecTreeToYamlStringConverter.convertSpecTreeToYamlString(map1))
         .isEqualTo(Files.readString(Path.of("src/test/resources/serializationSample.yaml")));
   }
 
@@ -42,10 +40,8 @@ class SpecTreeToYamlStringConverterTest {
 
     map1.put("key", null);
 
-    var specTreeToYamlStringsConverter = new SpecTreeToYamlStringConverter();
-
     assertThrows(
         UnexpectedTypeException.class,
-        () -> specTreeToYamlStringsConverter.convertSpecTreeToYamlString(map1));
+        () -> SpecTreeToYamlStringConverter.convertSpecTreeToYamlString(map1));
   }
 }

--- a/library/src/test/java/SpecTreeToYamlStringConverterTest.java
+++ b/library/src/test/java/SpecTreeToYamlStringConverterTest.java
@@ -1,0 +1,35 @@
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import org.junit.jupiter.api.Test;
+
+class SpecTreeToYamlStringConverterTest {
+  @Test
+  void testConvertMapToYamlString() throws IOException, UnexpectedDataException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/serializationSample.yaml");
+
+    var specTreeToYamlStringsConverter = new SpecTreeToYamlStringConverter();
+
+    assertThat(specTreeToYamlStringsConverter.convertSpecTreeToYamlString(map1))
+        .isEqualTo(Files.readString(Path.of("src/test/resources/serializationSample.yaml")));
+  }
+
+  @Test
+  void testSerializeMapWithUnexpectedDataThrows() {
+    LinkedHashMap<String, Object> map1 = new LinkedHashMap<>();
+
+    map1.put("key", null);
+
+    var specTreeToYamlStringsConverter = new SpecTreeToYamlStringConverter();
+
+    assertThrows(
+        UnexpectedDataException.class,
+        () -> specTreeToYamlStringsConverter.convertSpecTreeToYamlString(map1));
+  }
+}

--- a/library/src/test/java/SpecTreeToYamlStringConverterTest.java
+++ b/library/src/test/java/SpecTreeToYamlStringConverterTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 class SpecTreeToYamlStringConverterTest {
   @Test
-  void testConvertMapToYamlString() throws IOException, UnexpectedTypeException {
+  void convertSpecTreeToYamlString_withMap_succeeds() throws IOException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/serializationSample.yaml");
@@ -35,7 +35,7 @@ class SpecTreeToYamlStringConverterTest {
   }
 
   @Test
-  void testSerializeMapWithUnexpectedDataThrows() {
+  void convertSpecTreeToYamlString_withInvalidData_succeeds() {
     LinkedHashMap<String, Object> map1 = new LinkedHashMap<>();
 
     map1.put("key", null);

--- a/library/src/test/resources/serializationSample.yaml
+++ b/library/src/test/resources/serializationSample.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.0
+info:
+  title: Swagger Petstore
+  license:
+    name: MIT
+  version: 1.0.2
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      tags:
+        - pets
+        - dogs
+      responses:
+        '201':
+          description: Null response
+        '202':
+          description: Hello world
+      operationId: listPets
+    post:
+      summary: Create a pet
+  /pets/{petId}:
+    get:
+      summary: hello
+      parameters:
+        - name: petId1
+          in: path
+        - name: petId2
+          in: path2
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /newPath:
+    get:
+      required: true
+      parameters:
+        - name: petId
+          schema:
+            type: string
+servers:
+  - url: http://petstore.swagger.io/v1
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string


### PR DESCRIPTION
NOTE: this PR is part 3 of a series of upcoming PRs and as such, some tests will be dependent on code in other branches. Breaking up into multiple PRs was done for reviewer ease.

- [x] write a custom serializer class to convert "spec trees" which are simply LinkedHashMap<String, Object>, into YAML strings.
- [x] Example flow where this will be used: when the user of the library wants to perform a union on two specs, they will provide those specs as strings. Then, we will convert those YAML strings into "spec trees" (LinkedHashMap<String, Object>) using the deserializer (https://github.com/googleinterns/spec-math/pull/8). Then, perform the union on those two trees. Finally serialize the resulting spec tree back into a YAML string to provide back to the user.
- [x] 100% test coverage

Why were existing libraries such as Jackson, snakeYAML, or yamlbeans not used? The DESERIALIZER (https://github.com/googleinterns/spec-math/pull/8) was written using Jackson library, and Jackson can also SERIALIZE the spec tree back into a YAML file. Unfortunately, these libraries had a lack of flexibility in serialization options, which caused very small formatting issues (a difference of a few spaces or a newline). Here are some examples of using existing libraries such as Jackson, with expected serialization (on the left) and actual (on the right). The custom serializer written in this PR achieves the expected output.

**Issues with existing libraries, and the reason for the custom serializer:**

One extra space at the end of the line using yamlbeans:
![pasted image 0 (2)](https://user-images.githubusercontent.com/31750066/86833899-23531280-c068-11ea-9df6-fb1dcae3a593.png)

Jackson:
![pasted image 0](https://user-images.githubusercontent.com/31750066/86833767-f868be80-c067-11ea-94d1-4d9d1a93f93d.png)
Jackson:
![pasted image 0 (1)](https://user-images.githubusercontent.com/31750066/86833808-07e80780-c068-11ea-9743-be5d5b95b826.png)




