### PR TITLE
[Library Supports Union -- PR 5] Logic for performing union on two spec trees

### DIFF
--- a/library/src/main/java/Conflict.java
+++ b/library/src/main/java/Conflict.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 import java.util.Objects;
 
+/** POJO which is used to represent a Conflict resulting from a union operation. */
 public class Conflict {
   private String keypath;
   private Object optionA;

--- a/library/src/main/java/Conflict.java
+++ b/library/src/main/java/Conflict.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 
 public class Conflict {
   private String keypath;
-
   private Object optionA;
   private Object optionB;
   private Object resolvedValue;
@@ -40,9 +39,7 @@ public class Conflict {
     this.optionB = optionB;
   }
 
-  /**
-   * getters are required for serialization of JSON string to conflict objects
-   */
+  /** getters are required for serialization of JSON string to conflict objects */
   public Object getOptionA() {
     return optionA;
   }

--- a/library/src/main/java/Conflict.java
+++ b/library/src/main/java/Conflict.java
@@ -33,6 +33,10 @@ public class Conflict {
     this.resolvedValue = "";
   }
 
+  /**
+   * Create this Conflict object with a conflicting keypath, and the two options for resolving the
+   * conflicts.
+   */
   public Conflict(String keypath, Object optionA, Object optionB) {
     this.keypath = keypath;
     this.optionA = optionA;

--- a/library/src/main/java/Conflict.java
+++ b/library/src/main/java/Conflict.java
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import java.util.Objects;
+
+public class Conflict {
+  private String keypath;
+
+  private Object optionA;
+  private Object optionB;
+  private Object resolvedValue;
+
+  /**
+   * The default constructor is needed for com.fasterxml.jackson.databind.ObjectMapper which is used
+   * in the {@code ConflictStringToConflictMapConverter} class
+   */
+  public Conflict() {
+    this.keypath = "";
+    this.optionA = "";
+    this.optionB = "";
+    this.resolvedValue = "";
+  }
+
+  public Conflict(String keypath, Object optionA, Object optionB) {
+    this.keypath = keypath;
+    this.optionA = optionA;
+    this.optionB = optionB;
+  }
+
+  /**
+   * getters are required for serialization of JSON string to conflict objects
+   */
+  public Object getOptionA() {
+    return optionA;
+  }
+
+  public Object getOptionB() {
+    return optionB;
+  }
+
+  public String getKeypath() {
+    return keypath;
+  }
+
+  public Object getResolvedValue() {
+    return resolvedValue;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    Conflict conflict = (Conflict) o;
+    return keypath.equals(conflict.keypath)
+        && optionA.equals(conflict.optionA)
+        && optionB.equals(conflict.optionB)
+        && Objects.equals(resolvedValue, conflict.resolvedValue);
+  }
+
+  @Override
+  public String toString() {
+    return "Conflict{"
+        + "keypath='"
+        + keypath
+        + '\''
+        + ", optionA='"
+        + optionA
+        + '\''
+        + ", optionB='"
+        + optionB
+        + '\''
+        + ", resolvedValue='"
+        + resolvedValue
+        + '\''
+        + '}';
+  }
+}

--- a/library/src/main/java/SpecTreesUnionizer.java
+++ b/library/src/main/java/SpecTreesUnionizer.java
@@ -22,9 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
-/**
- * Provides functions for performing union operations on spec trees represented as Maps.
- */
+/** Provides functions for performing union operations on spec trees represented as Maps. */
 public class SpecTreesUnionizer {
   /**
    * Performs a union on {@code map1} and {@code map2} and returns the result.
@@ -36,7 +34,7 @@ public class SpecTreesUnionizer {
    */
   static LinkedHashMap<String, Object> union(
       LinkedHashMap<String, Object> map1, LinkedHashMap<String, Object> map2)
-      throws UnionConflictException, UnexpectedDataException {
+      throws UnionConflictException, UnexpectedTypeException {
     UnionizerUnionParams unionizerUnionParams = UnionizerUnionParams.builder().build();
 
     return union(map1, map2, unionizerUnionParams);
@@ -57,7 +55,7 @@ public class SpecTreesUnionizer {
       LinkedHashMap<String, Object> map1,
       LinkedHashMap<String, Object> map2,
       UnionizerUnionParams unionizerUnionParams)
-      throws UnionConflictException, UnexpectedDataException {
+      throws UnionConflictException, UnexpectedTypeException {
     var conflicts = new ArrayList<Conflict>();
     LinkedHashMap<String, Object> mergedMap =
         union(
@@ -112,7 +110,7 @@ public class SpecTreesUnionizer {
    */
   static LinkedHashMap<String, Object> applyOverlay(
       LinkedHashMap<String, Object> defaults, LinkedHashMap<String, Object> map2)
-      throws UnexpectedDataException {
+      throws UnexpectedTypeException {
     return union(
         defaults,
         map2,
@@ -144,7 +142,7 @@ public class SpecTreesUnionizer {
       Stack<String> keypath,
       ArrayList<Conflict> conflicts,
       HashMap<String, Object> conflictResolutions)
-      throws UnexpectedDataException {
+      throws UnexpectedTypeException {
 
     for (Map.Entry<String, Object> entry : map2.entrySet()) {
       String key = entry.getKey();
@@ -175,7 +173,7 @@ public class SpecTreesUnionizer {
           } else {
             // Either an unexpected type was met, or one map had a different type (primitive, map,
             // list) as a value compared to the other.
-            throw new UnexpectedDataException("Unexpected Data During Union");
+            throw new UnexpectedTypeException("Unexpected Data During Union");
           }
         }
 
@@ -210,7 +208,7 @@ public class SpecTreesUnionizer {
       String key,
       Object valueMap2,
       Object valueMap1)
-      throws UnexpectedDataException {
+      throws UnexpectedTypeException {
     LinkedHashMap<String, Object> value1Map = ObjectCaster.castObjectToStringObjectMap(valueMap1);
     LinkedHashMap<String, Object> value2Map = ObjectCaster.castObjectToStringObjectMap(valueMap2);
     map1.put(

--- a/library/src/main/java/SpecTreesUnionizer.java
+++ b/library/src/main/java/SpecTreesUnionizer.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
+/**
+ * Provides functions for performing union operations on spec trees represented as Maps.
+ */
 public class SpecTreesUnionizer {
   /**
    * Performs a union on {@code map1} and {@code map2} and returns the result.

--- a/library/src/main/java/SpecTreesUnionizer.java
+++ b/library/src/main/java/SpecTreesUnionizer.java
@@ -1,0 +1,255 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+public class SpecTreesUnionizer {
+  /**
+   * Performs a union on {@code map1} and {@code map2} and returns the result.
+   *
+   * @param map1 the map which {@code map2} is merged into. {@code map1} will contain the result of
+   *     the union.
+   * @param map2 the map to merge into {@code map1}
+   * @return the result of a union on {@code map1} and {@code map2}
+   */
+  static LinkedHashMap<String, Object> union(
+      LinkedHashMap<String, Object> map1, LinkedHashMap<String, Object> map2)
+      throws UnionConflictException, UnexpectedDataException {
+    UnionizerUnionParams unionizerUnionParams = UnionizerUnionParams.builder().build();
+
+    return union(map1, map2, unionizerUnionParams);
+  }
+
+  /**
+   * Performs a union on {@code map1} and {@code map2} with the given {@code unionizerUnionParams}
+   * and returns the result.
+   *
+   * @param map1 the map which {@code map2} is merged into. {@code map1} will contain the result of
+   *     the union.
+   * @param map2 the map to merge into {@code map1}
+   * @param unionizerUnionParams a set of special options which can be applied during the union
+   * @return the result of a union on {@code map1} and {@code map2} with options from {@code
+   *     unionizerUnionParams} applied
+   */
+  static LinkedHashMap<String, Object> union(
+      LinkedHashMap<String, Object> map1,
+      LinkedHashMap<String, Object> map2,
+      UnionizerUnionParams unionizerUnionParams)
+      throws UnionConflictException, UnexpectedDataException {
+    var conflicts = new ArrayList<Conflict>();
+    LinkedHashMap<String, Object> mergedMap =
+        union(
+            map1,
+            map2,
+            false,
+            new Stack<String>(),
+            conflicts,
+            unionizerUnionParams.conflictResolutions());
+
+    removeConflictsFixedByDefaults(unionizerUnionParams.defaults(), conflicts);
+
+    LinkedHashMap<String, Object> defaultsMap =
+        new LinkedHashMap<>(unionizerUnionParams.defaults());
+
+    LinkedHashMap<String, Object> resolvedMap = applyOverlay(defaultsMap, mergedMap);
+
+    if (conflicts.isEmpty()) {
+      return resolvedMap;
+    } else {
+      throw new UnionConflictException(conflicts);
+    }
+  }
+
+  /**
+   * Removes conflicts from {@code conflicts} parameter passed by reference if the conflicting
+   * keypath is also a path in the defaults map.
+   *
+   * @param defaults a map which contains defaults to apply to some output of a union
+   * @param conflicts an ArrayList passed by reference, which gets updated based on the conflicts
+   *     which do not occur thanks to the default map
+   */
+  private static void removeConflictsFixedByDefaults(
+      LinkedHashMap<String, Object> defaults, ArrayList<Conflict> conflicts) {
+
+    var defaultKeypaths = new HashSet<String>();
+
+    MapUtils.getKeypathsFromMap(defaults, new Stack<>(), defaultKeypaths);
+
+    conflicts.removeIf(conflict -> defaultKeypaths.contains(conflict.getKeypath()));
+  }
+
+  /**
+   * Performs a union on {@code defaults} and {@code map2} and returns the result. Conflicts are
+   * resolved by using the {@code defaults} map as priority.
+   *
+   * @param defaults the map which {@code map2} is merged into. {@code defaults} will contain the
+   *     result of the union and will take priority over {@code map2} in the case of conflicts.
+   * @param map2 the map to merge into {@code defaults}
+   * @return the result of a union on {@code defaults} and {@code map2}, where conflicts are
+   *     resolved by using the {@code defaults} map as priority.
+   */
+  static LinkedHashMap<String, Object> applyOverlay(
+      LinkedHashMap<String, Object> defaults, LinkedHashMap<String, Object> map2)
+      throws UnexpectedDataException {
+    return union(
+        defaults,
+        map2,
+        true,
+        new Stack<String>(),
+        new ArrayList<Conflict>(),
+        new HashMap<String, Object>());
+  }
+
+  /**
+   * Union function with all possible options. Other functions provide a nicer interface for
+   * different use cases of union, and ultimately call this function.
+   *
+   * @param map1 map 1/2 to merge. This map is special because it can take priority in the union
+   *     based on {@code map1IsDefault} flag
+   * @param map2 map 2/2 to merge
+   * @param map1IsDefault if true, map1 will take priority over map2 in case of different leaf
+   *     values, and no conflict will be reported
+   * @param keypath the key path which the leaf nodes belong to in the current iteration of the
+   *     recursive frame
+   * @param conflicts appended to if there is an unresolvable conflict
+   * @param conflictResolutions a map which can provide conflict resolutions based on keypaths
+   * @return the result of union on {@code map1} and {@code map2}
+   */
+  private static LinkedHashMap<String, Object> union(
+      LinkedHashMap<String, Object> map1,
+      LinkedHashMap<String, Object> map2,
+      boolean map1IsDefault,
+      Stack<String> keypath,
+      ArrayList<Conflict> conflicts,
+      HashMap<String, Object> conflictResolutions)
+      throws UnexpectedDataException {
+
+    for (Map.Entry<String, Object> entry : map2.entrySet()) {
+      String key = entry.getKey();
+      Object value2 = entry.getValue();
+
+      keypath.push(key);
+
+      if (map1.containsKey(entry.getKey())) {
+        Object value1 = map1.get(key);
+
+        if (!value1.equals(value2)) {
+          if (TypeChecker.isObjectMap(value1) && TypeChecker.isObjectMap((value2))) {
+            // We have two maps which contain the same key, add the key and process maps further.
+            processUnequalSubtrees(
+                map1, map1IsDefault, keypath, conflicts, conflictResolutions, key, value2, value1);
+          } else if (TypeChecker.isObjectList(value1)
+              && TypeChecker.isObjectList(value2)
+              && !map1IsDefault) {
+            List<Object> output =
+                ListUtils.listUnion(
+                    ObjectCaster.castObjectToListOfObjects(value1),
+                    ObjectCaster.castObjectToListOfObjects(value2));
+            map1.put(key, output);
+          } else if (TypeChecker.isObjectPrimitive(value1)
+              && TypeChecker.isObjectPrimitive(value2)) {
+            processUnequalLeafNodes(
+                map1, key, value1, value2, map1IsDefault, keypath, conflicts, conflictResolutions);
+          } else {
+            // Either an unexpected type was met, or one map had a different type (primitive, map,
+            // list) as a value compared to the other.
+            throw new UnexpectedDataException("Unexpected Data During Union");
+          }
+        }
+
+      } else {
+        // map2 contains a key which map1 does not have, so just add the entire subtree / leaf node.
+        map1.put(key, value2);
+      }
+
+      // Backtrack on the keypath.
+      keypath.pop();
+    }
+
+    return map1;
+  }
+
+  /**
+   * Used by the union function when two subtrees are different. We have two maps which contain the
+   * same key, add the key and process maps further.
+   *
+   * @param map1 the output map
+   * @param keypath the keypath to the current node
+   * @param key the key shared by the two subtrees
+   * @param valueMap2 subtree 2, to be processed further
+   * @param valueMap1 subtree 1, to be processed further
+   */
+  private static void processUnequalSubtrees(
+      LinkedHashMap<String, Object> map1,
+      boolean map1IsDefault,
+      Stack<String> keypath,
+      ArrayList<Conflict> conflicts,
+      HashMap<String, Object> conflictResolutions,
+      String key,
+      Object valueMap2,
+      Object valueMap1)
+      throws UnexpectedDataException {
+    LinkedHashMap<String, Object> value1Map = ObjectCaster.castObjectToStringObjectMap(valueMap1);
+    LinkedHashMap<String, Object> value2Map = ObjectCaster.castObjectToStringObjectMap(valueMap2);
+    map1.put(
+        key, union(value1Map, value2Map, map1IsDefault, keypath, conflicts, conflictResolutions));
+  }
+
+  /**
+   * Used by the union function when two leaf nodes are different. If {@code map1IsDefault} is true,
+   * then there is no conflict. Otherwise, there is a conflict if there is no {@code key} in {@code
+   * conflictResolutions} that matches the {@code keypath} of the current nodes. In the case of a
+   * conflict, add it to the {@code conflictResolutions} array.
+   *
+   * @param map1 the output map, which may be added to
+   * @param key the key which both leaf nodes belong to
+   * @param value1 the first value to consider
+   * @param value2 the second value to consider. If it is different from value2 and cannot be
+   *     resolved by either defaults or conflictResolutions, then there is a conflict
+   * @param map1IsDefault if true, nothing is done since {@code value1} already contains the correct
+   *     value.
+   * @param keypath the key path which both leaf nodes belong to
+   * @param conflicts appended to if there is an unresolvable conflict
+   * @param conflictResolutions a map which can provide conflict resolutions based on keypaths
+   */
+  private static void processUnequalLeafNodes(
+      LinkedHashMap<String, Object> map1,
+      String key,
+      Object value1,
+      Object value2,
+      boolean map1IsDefault,
+      Stack<String> keypath,
+      ArrayList<Conflict> conflicts,
+      HashMap<String, Object> conflictResolutions) {
+
+    if (!map1IsDefault) {
+      String keypathString = keypath.toString();
+      if (conflictResolutions.containsKey(keypathString)) {
+        // can be resolved by a conflictResolution
+        map1.put(key, conflictResolutions.get(keypathString));
+      } else {
+        Conflict conflict = new Conflict(keypathString, value1, value2);
+        conflicts.add(conflict);
+      }
+    }
+  }
+}

--- a/library/src/main/java/UnionConflictException.java
+++ b/library/src/main/java/UnionConflictException.java
@@ -17,7 +17,7 @@ limitations under the License.
 import java.util.ArrayList;
 
 /**
- * A conflict thrown when a union operation resulted in one more conflicts, represented as {@code
+ * An exception thrown when a union operation resulted in one more conflicts, represented as {@code
  * Conflict} objects
  */
 public class UnionConflictException extends Exception {

--- a/library/src/main/java/UnionConflictException.java
+++ b/library/src/main/java/UnionConflictException.java
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import java.util.ArrayList;
+
+public class UnionConflictException extends Exception {
+  private ArrayList<Conflict> conflicts;
+
+  public UnionConflictException(ArrayList<Conflict> conflicts) {
+    this.conflicts = conflicts;
+  }
+
+  public ArrayList<Conflict> getConflicts() {
+    return conflicts;
+  }
+}

--- a/library/src/main/java/UnionConflictException.java
+++ b/library/src/main/java/UnionConflictException.java
@@ -16,19 +16,19 @@ limitations under the License.
 
 import java.util.ArrayList;
 
+/**
+ * A conflict thrown when a union operation resulted in one more conflicts, represented as {@code
+ * Conflict} objects
+ */
 public class UnionConflictException extends Exception {
   private ArrayList<Conflict> conflicts;
 
-  /**
-   * Create this exception, initialized with an array of {@code Conflict} objects.
-   */
+  /** Create this exception, initialized with an array of {@code Conflict} objects. */
   public UnionConflictException(ArrayList<Conflict> conflicts) {
     this.conflicts = conflicts;
   }
 
-  /**
-   * @return the array of {@code Conflict} objects contained within this exception
-   */
+  /** @return the array of {@code Conflict} objects contained within this exception */
   public ArrayList<Conflict> getConflicts() {
     return conflicts;
   }

--- a/library/src/main/java/UnionConflictException.java
+++ b/library/src/main/java/UnionConflictException.java
@@ -19,10 +19,16 @@ import java.util.ArrayList;
 public class UnionConflictException extends Exception {
   private ArrayList<Conflict> conflicts;
 
+  /**
+   * Create this exception, initialized with an array of {@code Conflict} objects.
+   */
   public UnionConflictException(ArrayList<Conflict> conflicts) {
     this.conflicts = conflicts;
   }
 
+  /**
+   * @return the array of {@code Conflict} objects contained within this exception
+   */
   public ArrayList<Conflict> getConflicts() {
     return conflicts;
   }

--- a/library/src/main/java/UnionizerUnionParams.java
+++ b/library/src/main/java/UnionizerUnionParams.java
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import com.google.auto.value.AutoValue;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+@AutoValue
+public abstract class UnionizerUnionParams {
+  public static Builder builder() {
+    return new AutoValue_UnionizerUnionParams.Builder()
+        .defaults(new LinkedHashMap<String, Object>())
+        .conflictResolutions(new HashMap<String, Object>());
+  }
+
+  public abstract LinkedHashMap<String, Object> defaults();
+
+  public abstract HashMap<String, Object> conflictResolutions();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder defaults(LinkedHashMap<String, Object> defaults);
+
+    public abstract Builder conflictResolutions(HashMap<String, Object> conflictResolutions);
+
+    public abstract UnionizerUnionParams build();
+  }
+}

--- a/library/src/main/java/UnionizerUnionParams.java
+++ b/library/src/main/java/UnionizerUnionParams.java
@@ -18,6 +18,7 @@ import com.google.auto.value.AutoValue;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 
+/** Used to provide additional parameters when calling functions of the SpecTreesUnionizer class. */
 @AutoValue
 public abstract class UnionizerUnionParams {
   public static Builder builder() {

--- a/library/src/test/java/SpecTreesUnionizerTest.java
+++ b/library/src/test/java/SpecTreesUnionizerTest.java
@@ -207,4 +207,19 @@ class SpecTreesUnionizerTest {
 
     assertThrows(UnexpectedDataException.class, () -> SpecTreesUnionizer.union(map1, map2));
   }
+
+  @Test
+  void testApplyOverlayMaps() throws UnexpectedDataException {
+    LinkedHashMap<String, Object> specString =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/elgoogMarketing.yaml");
+    LinkedHashMap<String, Object> overlay =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/elgoogMetadata.yaml");
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/elgoogBillingOverlayedWithMetadata.yaml");
+
+    assertThat(SpecTreesUnionizer.applyOverlay(overlay, specString)).isEqualTo(expected);
+  }
 }

--- a/library/src/test/java/SpecTreesUnionizerTest.java
+++ b/library/src/test/java/SpecTreesUnionizerTest.java
@@ -209,7 +209,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testApplyOverlayMaps() throws UnexpectedDataException {
+  void testApplyOverlayMaps() throws UnexpectedDataException, FileNotFoundException {
     LinkedHashMap<String, Object> specString =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/elgoogMarketing.yaml");

--- a/library/src/test/java/SpecTreesUnionizerTest.java
+++ b/library/src/test/java/SpecTreesUnionizerTest.java
@@ -33,7 +33,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testUnionMapsWithoutConflicts()
+  void union_withoutConflicts_succeeds()
       throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
@@ -50,7 +50,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testUnionMapsWithConflictResolutionsAndDefaults()
+  void union_withConflictResolutionsAndDefaults_succeeds()
       throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
@@ -79,7 +79,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testUnionMapsWithConflictsThrows() throws FileNotFoundException {
+  void union_withConflicts_throwsWithExceptionContainingConflictObjects() throws FileNotFoundException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/simplepetstore.yaml");
@@ -103,7 +103,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testUnionMapsWithConflictsFixedByDefaults()
+  void union_withConflicts_succeedsByResolvingWithDefaults()
       throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
@@ -126,7 +126,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testUnionMapsWithConflictsFixedByConflictResolutions()
+  void union_withConflicts_succeedsByResolvingWithConflictResolutions()
       throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
@@ -149,7 +149,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testUnionMapsWithConflictsNotFixedByInvalidConflictResolutions()
+  void union_withConflicts_notFixedByInvalidConflictResolutions()
       throws FileNotFoundException, UnionConflictException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
@@ -170,7 +170,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testUnionMapsDoesNotApplyUnnecessaryConflictResolutions()
+  void union_withUnnecessaryConflictResolutions_succeedsButDoesNotApplyTheResolutions()
       throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
@@ -198,7 +198,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testUnionMapsWithUnexpectedDataThrows() {
+  void union_withUnexpectedData_throws() {
     LinkedHashMap<String, Object> map1 = new LinkedHashMap<>();
     LinkedHashMap<String, Object> map2 = new LinkedHashMap<>();
 
@@ -209,7 +209,7 @@ class SpecTreesUnionizerTest {
   }
 
   @Test
-  void testApplyOverlayMaps() throws UnexpectedTypeException, FileNotFoundException {
+  void applyOverlay_succeeds() throws UnexpectedTypeException, FileNotFoundException {
     LinkedHashMap<String, Object> specString =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/elgoogMarketing.yaml");

--- a/library/src/test/java/SpecTreesUnionizerTest.java
+++ b/library/src/test/java/SpecTreesUnionizerTest.java
@@ -1,0 +1,210 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SpecTreesUnionizerTest {
+  YamlStringToSpecTreeConverter yamlStringToSpecTreeConverter;
+
+  @BeforeEach
+  void init() {
+    yamlStringToSpecTreeConverter = new YamlStringToSpecTreeConverter();
+  }
+
+  @Test
+  void testUnionMapsWithoutConflicts()
+      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/noConflict1.yaml");
+    LinkedHashMap<String, Object> map2 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/noConflict2.yaml");
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/noConflictMerged.yaml");
+
+    assertThat(SpecTreesUnionizer.union(map1, map2)).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionMapsWithConflictResolutionsAndDefaults()
+      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflict1.yaml");
+    LinkedHashMap<String, Object> map2 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflict2.yaml");
+    LinkedHashMap<String, Object> defaults =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflictDefaults.yaml");
+
+    HashMap<String, Object> conflictResolutions = new HashMap<>();
+    conflictResolutions.put("[paths, /pets, get, summary]", "CONFLICT RESOLVED");
+
+    UnionizerUnionParams unionizerUnionParams =
+        UnionizerUnionParams.builder()
+            .defaults(defaults)
+            .conflictResolutions(conflictResolutions)
+            .build();
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflictsMergedWithDefaults.yaml");
+
+    assertThat(SpecTreesUnionizer.union(map1, map2, unionizerUnionParams)).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionMapsWithConflictsThrows() throws FileNotFoundException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/simplepetstore.yaml");
+    LinkedHashMap<String, Object> map2 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/simplepetstore2.yaml");
+    UnionizerUnionParams unionizerUnionParams = UnionizerUnionParams.builder().build();
+
+    UnionConflictException e =
+        assertThrows(
+            UnionConflictException.class,
+            () -> SpecTreesUnionizer.union(map1, map2, unionizerUnionParams));
+
+    ArrayList<Conflict> expectedConflicts = new ArrayList<>();
+    expectedConflicts.add(
+        new Conflict("[info, title]", "Swagger Petstore Platform", "Swagger Petstore Marketing"));
+    expectedConflicts.add(
+        new Conflict("[paths, /pets, get, summary]", "List all pets", "List every pet"));
+
+    assertThat(e.getConflicts()).isEqualTo(expectedConflicts);
+  }
+
+  @Test
+  void testUnionMapsWithConflictsFixedByDefaults()
+      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/simplepetstore.yaml");
+    LinkedHashMap<String, Object> map2 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/simplepetstore2.yaml");
+    LinkedHashMap<String, Object> defaults =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/simplepetstoredefaults.yaml");
+
+    UnionizerUnionParams unionizerUnionParams =
+        UnionizerUnionParams.builder().defaults(defaults).build();
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/simplepetstoremerged.yaml");
+
+    assertThat(SpecTreesUnionizer.union(map1, map2, unionizerUnionParams)).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionMapsWithConflictsFixedByConflictResolutions()
+      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflict1.yaml");
+    LinkedHashMap<String, Object> map2 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflict2.yaml");
+
+    HashMap<String, Object> conflictResolutions = new HashMap<>();
+    conflictResolutions.put("[paths, /pets, get, summary]", "CONFLICT RESOLVED");
+
+    UnionizerUnionParams unionizerUnionParams =
+        UnionizerUnionParams.builder().conflictResolutions(conflictResolutions).build();
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflictMerged.yaml");
+
+    assertThat(SpecTreesUnionizer.union(map1, map2, unionizerUnionParams)).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionMapsWithConflictsNotFixedByInvalidConflictResolutions()
+      throws FileNotFoundException, UnionConflictException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflict1.yaml");
+    LinkedHashMap<String, Object> map2 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/conflict2.yaml");
+
+    HashMap<String, Object> conflictResolutions = new HashMap<>();
+    conflictResolutions.put("[this, /isnt, a, path]", "CONFLICT RESOLVED");
+
+    UnionizerUnionParams unionizerUnionParams =
+        UnionizerUnionParams.builder().conflictResolutions(conflictResolutions).build();
+
+    assertThrows(
+        UnionConflictException.class,
+        () -> SpecTreesUnionizer.union(map1, map2, unionizerUnionParams));
+  }
+
+  @Test
+  void testUnionMapsDoesNotApplyUnnecessaryConflictResolutions()
+      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/noConflict1.yaml");
+    LinkedHashMap<String, Object> map2 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/noConflict2.yaml");
+
+    HashMap<String, Object> conflictResolutions = new HashMap<>();
+    conflictResolutions.put("[info, title]", "CONFLICT RESOLUTION TITLE");
+
+    UnionizerUnionParams unionizerUnionParams =
+        UnionizerUnionParams.builder().conflictResolutions(conflictResolutions).build();
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/noConflictMerged.yaml");
+
+    var actual = SpecTreesUnionizer.union(map1, map2, unionizerUnionParams);
+
+    assertThat(ObjectCaster.castObjectToStringObjectMap(actual.get("info")).get("title"))
+        .isNotEqualTo("CONFLICT RESOLUTION TITLE");
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionMapsWithUnexpectedDataThrows() {
+    LinkedHashMap<String, Object> map1 = new LinkedHashMap<>();
+    LinkedHashMap<String, Object> map2 = new LinkedHashMap<>();
+
+    map1.put("samekey", new LinkedHashMap<String, Object>());
+    map2.put("samekey", "not a map");
+
+    assertThrows(UnexpectedDataException.class, () -> SpecTreesUnionizer.union(map1, map2));
+  }
+}

--- a/library/src/test/java/SpecTreesUnionizerTest.java
+++ b/library/src/test/java/SpecTreesUnionizerTest.java
@@ -34,7 +34,7 @@ class SpecTreesUnionizerTest {
 
   @Test
   void testUnionMapsWithoutConflicts()
-      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/noConflict1.yaml");
@@ -51,7 +51,7 @@ class SpecTreesUnionizerTest {
 
   @Test
   void testUnionMapsWithConflictResolutionsAndDefaults()
-      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/conflict1.yaml");
@@ -63,7 +63,7 @@ class SpecTreesUnionizerTest {
             "src/test/resources/conflictDefaults.yaml");
 
     HashMap<String, Object> conflictResolutions = new HashMap<>();
-    conflictResolutions.put("[paths, /pets, get, summary]", "CONFLICT RESOLVED");
+    conflictResolutions.put("[paths, /pets, get, summary]", "get the pets");
 
     UnionizerUnionParams unionizerUnionParams =
         UnionizerUnionParams.builder()
@@ -104,7 +104,7 @@ class SpecTreesUnionizerTest {
 
   @Test
   void testUnionMapsWithConflictsFixedByDefaults()
-      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/simplepetstore.yaml");
@@ -127,7 +127,7 @@ class SpecTreesUnionizerTest {
 
   @Test
   void testUnionMapsWithConflictsFixedByConflictResolutions()
-      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/conflict1.yaml");
@@ -136,7 +136,7 @@ class SpecTreesUnionizerTest {
             "src/test/resources/conflict2.yaml");
 
     HashMap<String, Object> conflictResolutions = new HashMap<>();
-    conflictResolutions.put("[paths, /pets, get, summary]", "CONFLICT RESOLVED");
+    conflictResolutions.put("[paths, /pets, get, summary]", "get the pets");
 
     UnionizerUnionParams unionizerUnionParams =
         UnionizerUnionParams.builder().conflictResolutions(conflictResolutions).build();
@@ -171,7 +171,7 @@ class SpecTreesUnionizerTest {
 
   @Test
   void testUnionMapsDoesNotApplyUnnecessaryConflictResolutions()
-      throws FileNotFoundException, UnionConflictException, UnexpectedDataException {
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> map1 =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/noConflict1.yaml");
@@ -205,11 +205,11 @@ class SpecTreesUnionizerTest {
     map1.put("samekey", new LinkedHashMap<String, Object>());
     map2.put("samekey", "not a map");
 
-    assertThrows(UnexpectedDataException.class, () -> SpecTreesUnionizer.union(map1, map2));
+    assertThrows(UnexpectedTypeException.class, () -> SpecTreesUnionizer.union(map1, map2));
   }
 
   @Test
-  void testApplyOverlayMaps() throws UnexpectedDataException, FileNotFoundException {
+  void testApplyOverlayMaps() throws UnexpectedTypeException, FileNotFoundException {
     LinkedHashMap<String, Object> specString =
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/elgoogMarketing.yaml");


### PR DESCRIPTION
NOTE: this PR is part 5 of a series of upcoming PRs and as such, some code will be dependent on code in other branches. Breaking up into multiple PRs was done for reviewer ease.

- [x] SpecTreesUnionizer can perform union on two spec trees represented as LinkedHashMap<String, Object>. This class will be used in the SpecMath class (PR upcoming) to provide the union logic to users of this library. 
- [x] The class also supports providing special options with UnionizerUnionParams using the builder pattern, which can be applied during the union.
- [x] Special options currently provide support for applying defaults and conflictResolutions.
- [x] UnionConflictException is the custom exception which is thrown by the SpecTreesUnionizer in case of conflicts. It holds an array of Conflict objects
- [x] Conflict objects will be used in other places e.g. for serializing conflictResolutions JSON, reporting conflicts back to the user, etc.
- [x] 100% test coverage of SpecTreesUnionizer, with example usage.