### PR TITLE
[Library Supports Union -- PR 6/6] Library supports union

### DIFF
--- a/library/src/main/java/ConflictStringToConflictMapConverter.java
+++ b/library/src/main/java/ConflictStringToConflictMapConverter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 
+/** Provides functions for deserializing representations of {@code Conflict} objects. */
 public class ConflictStringToConflictMapConverter {
 
   /**

--- a/library/src/main/java/ConflictStringToConflictMapConverter.java
+++ b/library/src/main/java/ConflictStringToConflictMapConverter.java
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+public class ConflictStringToConflictMapConverter {
+
+  /**
+   * Takes a JSON string {@code conflictResolutions} which contains an array of {@code Conflict}
+   * objects and converts it into a HashMap in which the key is the keypath of a conflict and the
+   * value is the resolved value.
+   *
+   * @param conflictResolutions a JSON string which contains an array of {@code Conflict} objects
+   * @return a HashMap which contains a mapping of keypath->value to resolve during union
+   * @throws IOException if there was a parsing issue
+   */
+  public HashMap<String, Object> convertConflictResolutionsStringToConflictMap(
+      String conflictResolutions) throws IOException {
+    var mapper = new ObjectMapper();
+
+    HashMap<String, Object> conflictMap = new HashMap<>();
+
+    if (!conflictResolutions.isEmpty()) {
+      List<Conflict> conflictObjs =
+          mapper.readValue(conflictResolutions, new TypeReference<List<Conflict>>() {});
+      for (Conflict conflictObj : conflictObjs) {
+        String keypath = conflictObj.getKeypath();
+        Object resolvedValue = conflictObj.getResolvedValue();
+        conflictMap.put(keypath, resolvedValue);
+      }
+    }
+
+    return conflictMap;
+  }
+}

--- a/library/src/main/java/SpecMath.java
+++ b/library/src/main/java/SpecMath.java
@@ -30,8 +30,8 @@ public class SpecMath {
    * provided in the SpecTreeUnionizer class. Since no special options are provided, it will attempt
    * the union and if any conflicts are found a {@code UnionConflictException} will be thrown.
    *
-   * @param spec1 the first spec to be merged.
-   * @param spec2 the second spec to be merged.
+   * @param spec1 an OpenAPI specification represented as a YAML string
+   * @param spec2 an OpenAPI specification represented as a YAML string
    * @return the result of the union on spec1 and spec2, as a YAML string.
    * @throws IOException if there was a parsing issue in reading conflictResolutions
    * @throws UnionConflictException if there was a conflict in the union process, i.e. when two
@@ -91,20 +91,20 @@ public class SpecMath {
    * Performs the overlay operation on two specs represented as strings by calling the {@code
    * applyOverlay} function of the {@code SpecTreeUnionizer} class.
    *
-   * @param spec a spec to apply the {@code overlay} to
-   * @param overlay a spec fragment which will take priority over {@code spec} during the union
-   *     process
+   * @param spec an OpenAPI specification represented as a YAML string
+   * @param overlay an OpenAPI spec fragment which will take priority over {@code spec} during the
+   *     union process
    * @return the result of applying {@code overlay} to {@code spec}, as a YAML string
    * @throws UnexpectedTypeException an unexpected type was met during the union
    */
   public static String applyOverlay(String overlay, String spec) throws UnexpectedTypeException {
-    LinkedHashMap<String, Object> spec1map =
+    LinkedHashMap<String, Object> specMap =
         YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(spec);
     LinkedHashMap<String, Object> overlayMap =
         YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(overlay);
 
     LinkedHashMap<String, Object> overlayResultMap =
-        SpecTreesUnionizer.applyOverlay(overlayMap, spec1map);
+        SpecTreesUnionizer.applyOverlay(overlayMap, specMap);
 
     return SpecTreeToYamlStringConverter.convertSpecTreeToYamlString(overlayResultMap);
   }

--- a/library/src/main/java/SpecMath.java
+++ b/library/src/main/java/SpecMath.java
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+/**
+ * Provides functions for performing operations such as union and overlay on OpenAPI specifications
+ * represented as YAML strings.
+ */
+public class SpecMath {
+  /**
+   * Performs the union operation on two specs represented as strings.
+   *
+   * <p>This operation will attempt to combine {@code spec1} and {@code spec2} using the logic
+   * provided in the SpecTreeUnionizer class. Since no special options are provided, it will attempt
+   * the union and if any conflicts are found a {@code UnionConflictException} will be thrown.
+   *
+   * @param spec1 the first spec to be merged.
+   * @param spec2 the second spec to be merged.
+   * @return the result of the union on spec1 and spec2, as a YAML string.
+   * @throws IOException if there was a parsing issue in reading conflictResolutions
+   * @throws UnionConflictException if there was a conflict in the union process, i.e. when two
+   *     keypaths have the same value.
+   * @throws UnexpectedTypeException an unexpected type was met during the union
+   */
+  public static String union(String spec1, String spec2)
+      throws IOException, UnionConflictException, UnexpectedTypeException {
+    UnionOptions params = UnionOptions.builder().build();
+
+    return union(spec1, spec2, params);
+  }
+
+  /**
+   * Performs the union operation on two specs represented as strings with {@code UnionOptions}.
+   *
+   * <p>If {@code UnionOptions} are provided, then it will apply the options as is appropriate based
+   * on the logic in the {@code SpecTreeUnionizer} class. If {@code UnionOptions} cannot resolve the
+   * conflict then a {@code UnionConflictException} will be thrown.
+   *
+   * @param spec1 an OpenAPI specification represented as a YAML string
+   * @param spec2 an OpenAPI specification represented as a YAML string
+   * @param unionOptions a set of special options which can be applied during the union
+   * @return the result of the union on spec1 and spec2, as a YAML string
+   * @throws IOException if there was a parsing issue in reading conflictResolutions
+   * @throws UnionConflictException if there was a conflict in the union process, i.e. when two
+   *     keypaths have the same value
+   * @throws UnexpectedTypeException an unexpected type was met during the union
+   */
+  public static String union(String spec1, String spec2, UnionOptions unionOptions)
+      throws IOException, UnionConflictException, UnexpectedTypeException {
+    LinkedHashMap<String, Object> spec1map =
+        YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(spec1);
+    LinkedHashMap<String, Object> spec2map =
+        YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(spec2);
+    LinkedHashMap<String, Object> defaults =
+        YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(unionOptions.defaults());
+
+    var conflictStringToConflictMapConverter = new ConflictStringToConflictMapConverter();
+    HashMap<String, Object> conflictResolutionsMap =
+        conflictStringToConflictMapConverter.convertConflictResolutionsStringToConflictMap(
+            unionOptions.conflictResolutions());
+
+    UnionizerUnionParams unionizerUnionParams =
+        UnionizerUnionParams.builder()
+            .defaults(defaults)
+            .conflictResolutions(conflictResolutionsMap)
+            .build();
+
+    LinkedHashMap<String, Object> unionResultMap =
+        SpecTreesUnionizer.union(spec1map, spec2map, unionizerUnionParams);
+
+    return SpecTreeToYamlStringConverter.convertSpecTreeToYamlString(unionResultMap);
+  }
+
+  /**
+   * Performs the overlay operation on two specs represented as strings by calling the {@code
+   * applyOverlay} function of the {@code SpecTreeUnionizer} class.
+   *
+   * @param spec a spec to apply the {@code overlay} to
+   * @param overlay a spec fragment which will take priority over {@code spec} during the union
+   *     process
+   * @return the result of applying {@code overlay} to {@code spec}, as a YAML string
+   * @throws UnexpectedTypeException an unexpected type was met during the union
+   */
+  public static String applyOverlay(String overlay, String spec) throws UnexpectedTypeException {
+    LinkedHashMap<String, Object> spec1map =
+        YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(spec);
+    LinkedHashMap<String, Object> overlayMap =
+        YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(overlay);
+
+    LinkedHashMap<String, Object> overlayResultMap =
+        SpecTreesUnionizer.applyOverlay(overlayMap, spec1map);
+
+    return SpecTreeToYamlStringConverter.convertSpecTreeToYamlString(overlayResultMap);
+  }
+}

--- a/library/src/main/java/UnionOptions.java
+++ b/library/src/main/java/UnionOptions.java
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import com.google.auto.value.AutoValue;
+
+/** Used to provide additional parameters when calling functions of the SpecMath class. */
+@AutoValue
+public abstract class UnionOptions {
+  public static Builder builder() {
+    return new AutoValue_UnionOptions.Builder().defaults("").conflictResolutions("");
+  }
+
+  public abstract String defaults();
+
+  public abstract String conflictResolutions();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder defaults(String defaults);
+
+    public abstract Builder conflictResolutions(String conflictResolutions);
+
+    public abstract UnionOptions build();
+  }
+}

--- a/library/src/test/java/ConflictStringToConflictMapConverterTest.java
+++ b/library/src/test/java/ConflictStringToConflictMapConverterTest.java
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConflictStringToConflictMapConverterTest {
+  ConflictStringToConflictMapConverter conflictStringToConflictMapConverter;
+
+  @BeforeEach
+  void init() {
+    conflictStringToConflictMapConverter = new ConflictStringToConflictMapConverter();
+  }
+
+  @Test
+  void testConvertEmptyConflictResolutionsString() throws IOException {
+    HashMap<String, Object> expected = new HashMap<>();
+
+    assertThat(
+            conflictStringToConflictMapConverter.convertConflictResolutionsStringToConflictMap(""))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  void testConvertConflictResolutionsString() throws IOException {
+    HashMap<String, Object> expected = new HashMap<>();
+    expected.put("[paths, /pets/{petId}, get, summary]", "get the specified pets");
+
+    String conflictResolutions =
+        Files.readString(Path.of("src/test/resources/conflictResolutions.json"));
+
+    assertThat(
+            conflictStringToConflictMapConverter.convertConflictResolutionsStringToConflictMap(
+                conflictResolutions))
+        .isEqualTo(expected);
+  }
+}

--- a/library/src/test/java/ConflictStringToConflictMapConverterTest.java
+++ b/library/src/test/java/ConflictStringToConflictMapConverterTest.java
@@ -32,7 +32,7 @@ class ConflictStringToConflictMapConverterTest {
   }
 
   @Test
-  void testConvertEmptyConflictResolutionsString() throws IOException {
+  void convertConflictResolutionsStringToConflictMap_emptyConflictResolutions_returnsEmptyMap() throws IOException {
     HashMap<String, Object> expected = new HashMap<>();
 
     assertThat(
@@ -41,7 +41,7 @@ class ConflictStringToConflictMapConverterTest {
   }
 
   @Test
-  void testConvertConflictResolutionsString() throws IOException {
+  void convertConflictResolutionsStringToConflictMap_withConflictResolution_succeeds() throws IOException {
     HashMap<String, Object> expected = new HashMap<>();
     expected.put("[paths, /pets/{petId}, get, summary]", "get the specified pets");
 

--- a/library/src/test/java/SpecMathTest.java
+++ b/library/src/test/java/SpecMathTest.java
@@ -1,0 +1,167 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class SpecMathTest {
+  @Test
+  void testUnionWithoutConflicts()
+      throws IOException, UnionConflictException, UnexpectedTypeException {
+    String spec1String = Files.readString(Path.of("src/test/resources/noConflict1.yaml"));
+    String spec2String = Files.readString(Path.of("src/test/resources/noConflict2.yaml"));
+    String actual = SpecMath.union(spec1String, spec2String);
+    String expectedString = Files.readString(Path.of("src/test/resources/noConflictMerged.yaml"));
+
+    assertThat(actual).isEqualTo(expectedString);
+  }
+
+  @Test
+  void testUnionWithConflictResolutionsAndDefaults()
+      throws IOException, UnionConflictException, UnexpectedTypeException {
+    String spec1String = Files.readString(Path.of("src/test/resources/conflict1.yaml"));
+    String spec2String = Files.readString(Path.of("src/test/resources/conflict2.yaml"));
+    String defaults = Files.readString(Path.of("src/test/resources/conflictDefaults.yaml"));
+
+    String conflictResolutions =
+        Files.readString(Path.of("src/test/resources/conflictsMergedResolutions.json"));
+
+    UnionOptions unionOptions =
+        UnionOptions.builder().defaults(defaults).conflictResolutions(conflictResolutions).build();
+    String actual = SpecMath.union(spec1String, spec2String, unionOptions);
+
+    String expected =
+        Files.readString(Path.of("src/test/resources/conflictsMergedWithDefaults.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionWithConflictsThrows() throws IOException {
+    String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
+    String spec2String = Files.readString(Path.of("src/test/resources/elgoogBilling.yaml"));
+
+    UnionConflictException e =
+        assertThrows(UnionConflictException.class, () -> SpecMath.union(spec1String, spec2String));
+
+    ArrayList<Conflict> expectedConflicts = new ArrayList<>();
+    expectedConflicts.add(
+        new Conflict("[info, title]", "Elgoog Marketing Team API", "Elgoog Billing Team API"));
+    expectedConflicts.add(
+        new Conflict(
+            "[info, description]",
+            "An API for Elgoog's marketing team",
+            "An API for Elgoog's billing team"));
+
+    assertThat(e.getConflicts()).isEqualTo(expectedConflicts);
+  }
+
+  @Test
+  void testUnionWithDefaults() throws IOException, UnionConflictException, UnexpectedTypeException {
+    String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
+    String spec2String = Files.readString(Path.of("src/test/resources/elgoogBilling.yaml"));
+    String defaults = Files.readString(Path.of("src/test/resources/elgoogMetadata.yaml"));
+
+    UnionOptions unionOptions = UnionOptions.builder().defaults(defaults).build();
+    String actual = SpecMath.union(spec1String, spec2String, unionOptions);
+
+    String expected =
+        Files.readString(Path.of("src/test/resources/elgoogBillingAndMarketingMetadataUnion.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionWithConflictsFixedByConflictResolutions()
+      throws IOException, UnionConflictException, UnexpectedTypeException {
+    String spec1String = Files.readString(Path.of("src/test/resources/conflict1.yaml"));
+    String spec2String = Files.readString(Path.of("src/test/resources/conflict2.yaml"));
+
+    String conflictResolutions =
+        Files.readString(Path.of("src/test/resources/conflictsMergedResolutions.json"));
+
+    UnionOptions unionOptions =
+        UnionOptions.builder().conflictResolutions(conflictResolutions).build();
+
+    String actual = SpecMath.union(spec1String, spec2String, unionOptions);
+
+    String expected = Files.readString(Path.of("src/test/resources/conflictMerged.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionWithConflictsNotFixedByInvalidConflictResolutions() throws IOException {
+    String spec1String = Files.readString(Path.of("src/test/resources/conflict1.yaml"));
+    String spec2String = Files.readString(Path.of("src/test/resources/conflict2.yaml"));
+
+    String conflictResolutions =
+        Files.readString(Path.of("src/test/resources/unnecessaryConflictResolution.json"));
+
+    UnionOptions unionOptions =
+        UnionOptions.builder().conflictResolutions(conflictResolutions).build();
+
+    assertThrows(
+        UnionConflictException.class, () -> SpecMath.union(spec1String, spec2String, unionOptions));
+  }
+
+  @Test
+  void testUnionDoesNotApplyUnnecessaryConflictResolutions()
+      throws IOException, UnionConflictException, UnexpectedTypeException {
+    String spec1String = Files.readString(Path.of("src/test/resources/noConflict1.yaml"));
+    String spec2String = Files.readString(Path.of("src/test/resources/noConflict2.yaml"));
+
+    String expected = Files.readString(Path.of("src/test/resources/noConflictMerged.yaml"));
+
+    String conflictResolutions =
+        Files.readString(Path.of("src/test/resources/unnecessaryConflictResolution.json"));
+
+    UnionOptions unionOptions =
+        UnionOptions.builder().conflictResolutions(conflictResolutions).build();
+
+    String actual = SpecMath.union(spec1String, spec2String, unionOptions);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void testUnionEqualStringsEqualsOriginalString()
+      throws IOException, UnionConflictException, UnexpectedTypeException {
+    String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
+    String spec2String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
+    String actual = SpecMath.union(spec1String, spec2String);
+    String expected = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void testApplyOverlay() throws IOException, UnexpectedTypeException {
+    String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
+    String overlay = Files.readString(Path.of("src/test/resources/elgoogMetadata.yaml"));
+    String actual = SpecMath.applyOverlay(overlay, spec1String);
+    String expected =
+        Files.readString(Path.of("src/test/resources/elgoogBillingOverlayedWithMetadata.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/library/src/test/java/SpecMathTest.java
+++ b/library/src/test/java/SpecMathTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 class SpecMathTest {
   @Test
-  void testUnionWithoutConflicts()
+  void union_withoutConflicts_succeeds()
       throws IOException, UnionConflictException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/noConflict1.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/noConflict2.yaml"));
@@ -36,7 +36,7 @@ class SpecMathTest {
   }
 
   @Test
-  void testUnionWithConflictResolutionsAndDefaults()
+  void union_withConflictResolutionsAndDefaults_succeeds()
       throws IOException, UnionConflictException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/conflict1.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/conflict2.yaml"));
@@ -56,7 +56,7 @@ class SpecMathTest {
   }
 
   @Test
-  void testUnionWithConflictsThrows() throws IOException {
+  void union_withConflicts_throws() throws IOException {
     String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/elgoogBilling.yaml"));
 
@@ -76,7 +76,7 @@ class SpecMathTest {
   }
 
   @Test
-  void testUnionWithDefaults() throws IOException, UnionConflictException, UnexpectedTypeException {
+  void union_withDefaults_succeeds() throws IOException, UnionConflictException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/elgoogBilling.yaml"));
     String defaults = Files.readString(Path.of("src/test/resources/elgoogMetadata.yaml"));
@@ -91,7 +91,7 @@ class SpecMathTest {
   }
 
   @Test
-  void testUnionWithConflictsFixedByConflictResolutions()
+  void union_withConflictsFixedByConflictResolutions_succeeds()
       throws IOException, UnionConflictException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/conflict1.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/conflict2.yaml"));
@@ -110,7 +110,7 @@ class SpecMathTest {
   }
 
   @Test
-  void testUnionWithConflictsNotFixedByInvalidConflictResolutions() throws IOException {
+  void union_withConflictsNotFixedByInvalidConflictResolutions_throws() throws IOException {
     String spec1String = Files.readString(Path.of("src/test/resources/conflict1.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/conflict2.yaml"));
 
@@ -125,7 +125,7 @@ class SpecMathTest {
   }
 
   @Test
-  void testUnionDoesNotApplyUnnecessaryConflictResolutions()
+  void union_withUnnecessaryConflictResolutions_doesNotApplyThem()
       throws IOException, UnionConflictException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/noConflict1.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/noConflict2.yaml"));
@@ -144,7 +144,7 @@ class SpecMathTest {
   }
 
   @Test
-  void testUnionEqualStringsEqualsOriginalString()
+  void union_withEqualStrings_returnsOriginalString()
       throws IOException, UnionConflictException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
@@ -155,7 +155,7 @@ class SpecMathTest {
   }
 
   @Test
-  void testApplyOverlay() throws IOException, UnexpectedTypeException {
+  void overlay_appliedToSpec_succeeds() throws IOException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
     String overlay = Files.readString(Path.of("src/test/resources/elgoogMetadata.yaml"));
     String actual = SpecMath.applyOverlay(overlay, spec1String);

--- a/library/src/test/java/UnionOptionsTest.java
+++ b/library/src/test/java/UnionOptionsTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class UnionParametersTest {
+class UnionOptionsTest {
   @Test
   void testUseUnionOptionsBuilderBuilds() {
     UnionOptions unionOptions =

--- a/library/src/test/java/UnionParametersTest.java
+++ b/library/src/test/java/UnionParametersTest.java
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UnionParametersTest {
+  @Test
+  void testUseUnionOptionsBuilderBuilds() {
+    UnionOptions unionOptions =
+        UnionOptions.builder()
+            .conflictResolutions("INVALID CONFLICT RESOLUTIONS")
+            .defaults("INVALID DEFAULTS")
+            .build();
+
+    assertThat(unionOptions.defaults()).isEqualTo("INVALID DEFAULTS");
+    assertThat(unionOptions.conflictResolutions()).isEqualTo("INVALID CONFLICT RESOLUTIONS");
+  }
+
+  @Test
+  void testUseUnionOptionsBuilderDefaultsEmpty() {
+    UnionOptions unionOptions =
+        UnionOptions.builder().conflictResolutions("INVALID CONFLICT RESOLUTIONS").build();
+
+    assertThat(unionOptions.defaults()).isEqualTo("");
+    assertThat(unionOptions.conflictResolutions()).isEqualTo("INVALID CONFLICT RESOLUTIONS");
+  }
+
+  @Test
+  void testUseUnionOptionsBuilderConflictResolutionsEmpty() {
+    UnionOptions unionOptions =
+        UnionOptions.builder().defaults("INVALID DEFAULTS").build();
+
+    assertThat(unionOptions.conflictResolutions()).isEqualTo("");
+    assertThat(unionOptions.defaults()).isEqualTo("INVALID DEFAULTS");
+  }
+
+  @Test
+  void testUseUnionOptionsBuilderEmpty() {
+    UnionOptions unionOptions = UnionOptions.builder().build();
+
+    assertThat(unionOptions.defaults()).isEqualTo("");
+    assertThat(unionOptions.conflictResolutions()).isEqualTo("");
+  }
+}


### PR DESCRIPTION
NOTE: this PR is part 6/6 of a series of upcoming PRs and as such, some code will be dependent on code in other branches. Breaking up into multiple PRs was done for reviewer ease.

- [x] SpecMath can perform union on two OpenAPI specs represented as YAML strings. 
- [x] Also supports providing special options with UnionOptions using the builder pattern, which are applied during the union.
- [x] Special options with UnionOptions currently provide support for applying defaults and conflictResolutions
- [x] ConflictStringToConflictMapConverter class deserializes a JSON file into the conflict object provided in another PR, and then turns it into a map so that the conflicting keypaths can be resolved during union.
- [x] 100% test coverage, which provide example usages of the SpecMath class