### PR TITLE
[FILTERING STEP 1] implement lower level filtering class for filtering based on FilterCriteria

### DIFF
--- a/library/src/main/java/AllUnmatchedFilterException.java
+++ b/library/src/main/java/AllUnmatchedFilterException.java
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/** An exception thrown when the result of a filter was empty. */
+public class AllUnmatchedFilterException extends Exception {
+  public AllUnmatchedFilterException(String message) {
+    super(message);
+  }
+}

--- a/library/src/main/java/FilterCriteria.java
+++ b/library/src/main/java/FilterCriteria.java
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Used to provide a piece of filtering criteria for the SpecTreeFilterer. */
+@AutoValue
+public abstract class FilterCriteria {
+  public static Builder builder() {
+    return new AutoValue_FilterCriteria.Builder().
+        pathRegex("").
+        operations(new ArrayList<String>()).
+        tags(new ArrayList<String>()).
+        removableTags(new ArrayList<String>());
+  }
+
+  public abstract String pathRegex();
+  public abstract List<String> operations();
+  public abstract List<String> tags();
+  public abstract List<String> removableTags();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder pathRegex(String pathRegex);
+    public abstract Builder operations(List<String> operations);
+    public abstract Builder removableTags(List<String> removableTags);
+    public abstract Builder tags(List<String> tags);
+
+    public abstract FilterCriteria build();
+  }
+}
+

--- a/library/src/main/java/FilterCriteria.java
+++ b/library/src/main/java/FilterCriteria.java
@@ -23,20 +23,20 @@ import java.util.List;
 public abstract class FilterCriteria {
   public static Builder builder() {
     return new AutoValue_FilterCriteria.Builder().
-        pathRegex("").
+        path("").
         operations(new ArrayList<String>()).
         tags(new ArrayList<String>()).
         removableTags(new ArrayList<String>());
   }
 
-  public abstract String pathRegex();
+  public abstract String path();
   public abstract List<String> operations();
   public abstract List<String> tags();
   public abstract List<String> removableTags();
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder pathRegex(String pathRegex);
+    public abstract Builder path(String path);
     public abstract Builder operations(List<String> operations);
     public abstract Builder removableTags(List<String> removableTags);
     public abstract Builder tags(List<String> tags);

--- a/library/src/main/java/SpecTreeFilterer.java
+++ b/library/src/main/java/SpecTreeFilterer.java
@@ -92,7 +92,7 @@ public class SpecTreeFilterer {
 
     var outputOperations = new LinkedHashMap<String, Object>();
 
-    if (filterCriteria.pathRegex().isEmpty() || endpoint.matches(filterCriteria.pathRegex())) {
+    if (filterCriteria.path().isEmpty() || matches(endpoint, filterCriteria.path())) {
       for (Entry<String, Object> operationEntry : endpointObject.entrySet()) {
         processOperation(filterCriteria, outputOperations, operationEntry);
       }
@@ -101,6 +101,15 @@ public class SpecTreeFilterer {
     if (!outputOperations.isEmpty()) {
       outputEndpoints.put(endpoint, outputOperations);
     }
+  }
+
+  public static boolean matches(String endpoint, String path) {
+    path = path
+        .replace(".", "\\.")
+        .replace("*", ".*")
+        .replace("{", "\\{")
+        .replace("}", "\\}");
+    return endpoint.matches(path);
   }
 
   private static void processOperation(

--- a/library/src/main/java/SpecTreeFilterer.java
+++ b/library/src/main/java/SpecTreeFilterer.java
@@ -1,0 +1,161 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class SpecTreeFilterer {
+
+  /**
+   * Filters an input spec tree {@code specToFilter} based on the {@code filterCriteriaArrayList}.
+   * Only the paths which match the properties in the filter will be kept. Also, only the relevant
+   * component refs will be kept.
+   *
+   * @param specToFilter the origin spec to filter on
+   * @param filterCriteriaArrayList a list of FilterCriteria objects used to filter {@code
+   *     specToFilter}
+   * @return a new spec which is the filtered version of {@code specToFilter} based on the {@code
+   *     filterCriteriaArrayList}
+   * @throws UnionConflictException if there was an issue when merging the results from each
+   *     FilterCriteria
+   * @throws UnexpectedTypeException if there was an issue when merging the results from each
+   *     FilterCriteria
+   * @throws AllUnmatchedFilterException the filtered result would have no paths
+   */
+  public static LinkedHashMap<String, Object> filter(
+      LinkedHashMap<String, Object> specToFilter, ArrayList<FilterCriteria> filterCriteriaArrayList)
+      throws UnionConflictException, UnexpectedTypeException, AllUnmatchedFilterException {
+    var outputSpec = new LinkedHashMap<String, Object>();
+
+    for (FilterCriteria filterCriteria : filterCriteriaArrayList) {
+      SpecTreesUnionizer.union(
+          outputSpec, filterUsingSingleFilterCriteria(specToFilter, filterCriteria));
+    }
+
+    if (!outputSpec.containsKey("paths")
+        || ObjectCaster.castObjectToStringObjectMap(outputSpec.get("paths")).isEmpty()) {
+      throw new AllUnmatchedFilterException(
+          "The filter criteria provided would result in an empty spec.");
+    }
+
+    LinkedHashMap<String, Object> components =
+        SpecTreeComponentSelector.getRelevantComponents(outputSpec);
+
+    if (!components.isEmpty()) {
+      outputSpec.put("components", components.get("components"));
+    } else outputSpec.remove("components");
+
+    return outputSpec;
+  }
+
+  private static LinkedHashMap<String, Object> filterUsingSingleFilterCriteria(
+      LinkedHashMap<String, Object> specToFilter, FilterCriteria filterCriteria) {
+    LinkedHashMap<String, Object> paths =
+        ObjectCaster.castObjectToStringObjectMap(specToFilter.get("paths"));
+
+    var outputEndpoints = new LinkedHashMap<String, Object>();
+
+    for (Map.Entry<String, Object> endpointEntry : paths.entrySet()) {
+      processEndpoint(filterCriteria, outputEndpoints, endpointEntry);
+    }
+
+    LinkedHashMap<String, Object> filteredSpec = new LinkedHashMap<>(specToFilter);
+    filteredSpec.put("paths", outputEndpoints);
+
+    return filteredSpec;
+  }
+
+  private static void processEndpoint(
+      FilterCriteria filterCriteria,
+      LinkedHashMap<String, Object> outputEndpoints,
+      Entry<String, Object> endpointEntry) {
+    String endpoint = endpointEntry.getKey(); // /pets
+
+    LinkedHashMap<String, Object> endpointObject =
+        ObjectCaster.castObjectToStringObjectMap(endpointEntry.getValue());
+
+    var outputOperations = new LinkedHashMap<String, Object>();
+
+    if (filterCriteria.pathRegex().isEmpty() || endpoint.matches(filterCriteria.pathRegex())) {
+      for (Entry<String, Object> operationEntry : endpointObject.entrySet()) {
+        processOperation(filterCriteria, outputOperations, operationEntry);
+      }
+    }
+
+    if (!outputOperations.isEmpty()) {
+      outputEndpoints.put(endpoint, outputOperations);
+    }
+  }
+
+  private static void processOperation(
+      FilterCriteria filterCriteria,
+      LinkedHashMap<String, Object> outputOperations,
+      Entry<String, Object> operationEntry) {
+    String operation = operationEntry.getKey(); // get, put, post etc.
+
+    if (filterCriteria.operations().isEmpty() || filterCriteria.operations().contains(operation)) {
+      LinkedHashMap<String, Object> operationObject =
+          ObjectCaster.castObjectToStringObjectMap(operationEntry.getValue());
+
+      List<Object> tags = ObjectCaster.castObjectToListOfObjects(operationObject.get("tags"));
+
+      if ((filterCriteria.tags().isEmpty() && filterCriteria.removableTags().isEmpty())) {
+        outputOperations.put(operation, operationObject);
+      } else {
+        processTags(filterCriteria, outputOperations, operation, operationObject, tags);
+      }
+    }
+  }
+
+  private static void processTags(
+      FilterCriteria filterCriteria,
+      LinkedHashMap<String, Object> outputOperations,
+      String operation,
+      LinkedHashMap<String, Object> operationObject,
+      List<Object> tags) {
+    if (operationObject.containsKey("tags")) {
+      for (Object tag : tags) {
+        if (processTagsDisjunction(
+            filterCriteria, outputOperations, operation, operationObject, tags, (String) tag)) {
+          break; // since its disjunction, one tag matched will be enough
+        }
+      }
+    }
+  }
+
+  private static boolean processTagsDisjunction(
+      FilterCriteria filterCriteria,
+      LinkedHashMap<String, Object> outputOperations,
+      String operation,
+      LinkedHashMap<String, Object> operationObject,
+      List<Object> tags,
+      String tag) {
+    String tagString = tag.toLowerCase();
+    if (filterCriteria.tags().contains(tagString)
+        || filterCriteria.removableTags().contains(tagString)) {
+      tags.removeIf(singleTag -> filterCriteria.removableTags().contains((String) singleTag));
+      if (!tags.isEmpty()) {
+        operationObject.put("tags", tags);
+      }
+      outputOperations.put(operation, operationObject);
+      return true;
+    }
+    return false;
+  }
+}

--- a/library/src/main/java/SpecTreesUnionizer.java
+++ b/library/src/main/java/SpecTreesUnionizer.java
@@ -152,14 +152,8 @@ public class SpecTreesUnionizer {
       keypath.push(keyOfMapToMerge);
 
       if (mapToMergeInto.containsKey(keyOfMapToMerge)) {
-        processSubtreesWithSameKey(
-            mapToMergeInto,
-            mapToMergeIntoIsDefault,
-            keypath,
-            conflicts,
-            conflictResolutions,
-            keyOfMapToMerge,
-            valueOfMapToMerge);
+        processSubtreesWithSameKey(mapToMergeInto, mapToMergeIntoIsDefault, keypath, conflicts,
+            conflictResolutions, keyOfMapToMerge, valueOfMapToMerge);
 
       } else {
         // mapToMerge contains a key which mapToMergeInto does not have, so just add the entire
@@ -174,61 +168,48 @@ public class SpecTreesUnionizer {
     return mapToMergeInto;
   }
 
-  private static void processSubtreesWithSameKey(
-      LinkedHashMap<String, Object> mapToMergeInto,
-      boolean mapToMergeIntoIsDefault,
-      Stack<String> keypath,
-      ArrayList<Conflict> conflicts,
-      HashMap<String, Object> conflictResolutions,
-      String key,
-      Object valueOfMapToMerge)
+  private static void processSubtreesWithSameKey(LinkedHashMap<String, Object> mapToMergeInto,
+      boolean mapToMergeIntoIsDefault, Stack<String> keypath, ArrayList<Conflict> conflicts,
+      HashMap<String, Object> conflictResolutions, String key, Object valueOfMapToMerge)
       throws UnexpectedTypeException {
     Object value1 = mapToMergeInto.get(key);
 
-    if (value1.equals(valueOfMapToMerge)) {
-      return;
-    }
-
-    if (TypeChecker.isObjectMap(value1) && TypeChecker.isObjectMap((valueOfMapToMerge))) {
-      // We have two maps which contain the same key, add the key and process maps further.
-      processUnequalSubtrees(
-          mapToMergeInto,
-          mapToMergeIntoIsDefault,
-          keypath,
-          conflicts,
-          conflictResolutions,
-          key,
-          valueOfMapToMerge,
-          value1);
-    } else if (TypeChecker.isObjectList(value1) && TypeChecker.isObjectList(valueOfMapToMerge)) {
-      processUnequalListNodes(mapToMergeInto, mapToMergeIntoIsDefault, key, valueOfMapToMerge,
-          value1);
-    } else if (TypeChecker.isObjectPrimitive(value1)
-        && TypeChecker.isObjectPrimitive(valueOfMapToMerge)) {
-      processUnequalLeafNodes(
-          mapToMergeInto,
-          key,
-          value1,
-          valueOfMapToMerge,
-          mapToMergeIntoIsDefault,
-          keypath,
-          conflicts,
-          conflictResolutions);
-    } else {
-      // Either an unexpected type was met, or one map had a different type (primitive, map,
-      // list) as a value compared to the other.
-      throw new UnexpectedTypeException("Unexpected Data During Union");
-    }
-  }
-
-  private static void processUnequalListNodes(LinkedHashMap<String, Object> mapToMergeInto,
-      boolean mapToMergeIntoIsDefault, String key, Object valueOfMapToMerge, Object value1) {
-    if (!mapToMergeIntoIsDefault) {
-      List<Object> output =
-          ListUtils.listUnion(
-              ObjectCaster.castObjectToListOfObjects(value1),
-              ObjectCaster.castObjectToListOfObjects(valueOfMapToMerge));
-      mapToMergeInto.put(key, output);
+    if (!value1.equals(valueOfMapToMerge)) {
+      if (TypeChecker.isObjectMap(value1) && TypeChecker.isObjectMap((valueOfMapToMerge))) {
+        // We have two maps which contain the same key, add the key and process maps further.
+        processUnequalSubtrees(
+            mapToMergeInto,
+            mapToMergeIntoIsDefault,
+            keypath,
+            conflicts,
+            conflictResolutions,
+            key,
+            valueOfMapToMerge,
+            value1);
+      } else if (TypeChecker.isObjectList(value1)
+          && TypeChecker.isObjectList(valueOfMapToMerge)
+          && !mapToMergeIntoIsDefault) {
+        List<Object> output =
+            ListUtils.listUnion(
+                ObjectCaster.castObjectToListOfObjects(value1),
+                ObjectCaster.castObjectToListOfObjects(valueOfMapToMerge));
+        mapToMergeInto.put(key, output);
+      } else if (TypeChecker.isObjectPrimitive(value1)
+          && TypeChecker.isObjectPrimitive(valueOfMapToMerge)) {
+        processUnequalLeafNodes(
+            mapToMergeInto,
+            key,
+            value1,
+            valueOfMapToMerge,
+            mapToMergeIntoIsDefault,
+            keypath,
+            conflicts,
+            conflictResolutions);
+      } else {
+        // Either an unexpected type was met, or one map had a different type (primitive, map,
+        // list) as a value compared to the other.
+        throw new UnexpectedTypeException("Unexpected Data During Union");
+      }
     }
   }
 
@@ -252,10 +233,10 @@ public class SpecTreesUnionizer {
       Object valueMapToMerge,
       Object valueMapToMergeInto)
       throws UnexpectedTypeException {
-    LinkedHashMap<String, Object> value1Map =
-        ObjectCaster.castObjectToStringObjectMap(valueMapToMergeInto);
-    LinkedHashMap<String, Object> value2Map =
-        ObjectCaster.castObjectToStringObjectMap(valueMapToMerge);
+    LinkedHashMap<String, Object> value1Map = ObjectCaster.castObjectToStringObjectMap(
+        valueMapToMergeInto);
+    LinkedHashMap<String, Object> value2Map = ObjectCaster.castObjectToStringObjectMap(
+        valueMapToMerge);
     mapToMergeInto.put(
         key, union(value1Map, value2Map, map1IsDefault, keypath, conflicts, conflictResolutions));
   }

--- a/library/src/main/java/SpecTreesUnionizer.java
+++ b/library/src/main/java/SpecTreesUnionizer.java
@@ -152,8 +152,14 @@ public class SpecTreesUnionizer {
       keypath.push(keyOfMapToMerge);
 
       if (mapToMergeInto.containsKey(keyOfMapToMerge)) {
-        processSubtreesWithSameKey(mapToMergeInto, mapToMergeIntoIsDefault, keypath, conflicts,
-            conflictResolutions, keyOfMapToMerge, valueOfMapToMerge);
+        processSubtreesWithSameKey(
+            mapToMergeInto,
+            mapToMergeIntoIsDefault,
+            keypath,
+            conflicts,
+            conflictResolutions,
+            keyOfMapToMerge,
+            valueOfMapToMerge);
 
       } else {
         // mapToMerge contains a key which mapToMergeInto does not have, so just add the entire
@@ -168,48 +174,61 @@ public class SpecTreesUnionizer {
     return mapToMergeInto;
   }
 
-  private static void processSubtreesWithSameKey(LinkedHashMap<String, Object> mapToMergeInto,
-      boolean mapToMergeIntoIsDefault, Stack<String> keypath, ArrayList<Conflict> conflicts,
-      HashMap<String, Object> conflictResolutions, String key, Object valueOfMapToMerge)
+  private static void processSubtreesWithSameKey(
+      LinkedHashMap<String, Object> mapToMergeInto,
+      boolean mapToMergeIntoIsDefault,
+      Stack<String> keypath,
+      ArrayList<Conflict> conflicts,
+      HashMap<String, Object> conflictResolutions,
+      String key,
+      Object valueOfMapToMerge)
       throws UnexpectedTypeException {
     Object value1 = mapToMergeInto.get(key);
 
-    if (!value1.equals(valueOfMapToMerge)) {
-      if (TypeChecker.isObjectMap(value1) && TypeChecker.isObjectMap((valueOfMapToMerge))) {
-        // We have two maps which contain the same key, add the key and process maps further.
-        processUnequalSubtrees(
-            mapToMergeInto,
-            mapToMergeIntoIsDefault,
-            keypath,
-            conflicts,
-            conflictResolutions,
-            key,
-            valueOfMapToMerge,
-            value1);
-      } else if (TypeChecker.isObjectList(value1)
-          && TypeChecker.isObjectList(valueOfMapToMerge)
-          && !mapToMergeIntoIsDefault) {
-        List<Object> output =
-            ListUtils.listUnion(
-                ObjectCaster.castObjectToListOfObjects(value1),
-                ObjectCaster.castObjectToListOfObjects(valueOfMapToMerge));
-        mapToMergeInto.put(key, output);
-      } else if (TypeChecker.isObjectPrimitive(value1)
-          && TypeChecker.isObjectPrimitive(valueOfMapToMerge)) {
-        processUnequalLeafNodes(
-            mapToMergeInto,
-            key,
-            value1,
-            valueOfMapToMerge,
-            mapToMergeIntoIsDefault,
-            keypath,
-            conflicts,
-            conflictResolutions);
-      } else {
-        // Either an unexpected type was met, or one map had a different type (primitive, map,
-        // list) as a value compared to the other.
-        throw new UnexpectedTypeException("Unexpected Data During Union");
-      }
+    if (value1.equals(valueOfMapToMerge)) {
+      return;
+    }
+
+    if (TypeChecker.isObjectMap(value1) && TypeChecker.isObjectMap((valueOfMapToMerge))) {
+      // We have two maps which contain the same key, add the key and process maps further.
+      processUnequalSubtrees(
+          mapToMergeInto,
+          mapToMergeIntoIsDefault,
+          keypath,
+          conflicts,
+          conflictResolutions,
+          key,
+          valueOfMapToMerge,
+          value1);
+    } else if (TypeChecker.isObjectList(value1) && TypeChecker.isObjectList(valueOfMapToMerge)) {
+      processUnequalListNodes(mapToMergeInto, mapToMergeIntoIsDefault, key, valueOfMapToMerge,
+          value1);
+    } else if (TypeChecker.isObjectPrimitive(value1)
+        && TypeChecker.isObjectPrimitive(valueOfMapToMerge)) {
+      processUnequalLeafNodes(
+          mapToMergeInto,
+          key,
+          value1,
+          valueOfMapToMerge,
+          mapToMergeIntoIsDefault,
+          keypath,
+          conflicts,
+          conflictResolutions);
+    } else {
+      // Either an unexpected type was met, or one map had a different type (primitive, map,
+      // list) as a value compared to the other.
+      throw new UnexpectedTypeException("Unexpected Data During Union");
+    }
+  }
+
+  private static void processUnequalListNodes(LinkedHashMap<String, Object> mapToMergeInto,
+      boolean mapToMergeIntoIsDefault, String key, Object valueOfMapToMerge, Object value1) {
+    if (!mapToMergeIntoIsDefault) {
+      List<Object> output =
+          ListUtils.listUnion(
+              ObjectCaster.castObjectToListOfObjects(value1),
+              ObjectCaster.castObjectToListOfObjects(valueOfMapToMerge));
+      mapToMergeInto.put(key, output);
     }
   }
 
@@ -233,10 +252,10 @@ public class SpecTreesUnionizer {
       Object valueMapToMerge,
       Object valueMapToMergeInto)
       throws UnexpectedTypeException {
-    LinkedHashMap<String, Object> value1Map = ObjectCaster.castObjectToStringObjectMap(
-        valueMapToMergeInto);
-    LinkedHashMap<String, Object> value2Map = ObjectCaster.castObjectToStringObjectMap(
-        valueMapToMerge);
+    LinkedHashMap<String, Object> value1Map =
+        ObjectCaster.castObjectToStringObjectMap(valueMapToMergeInto);
+    LinkedHashMap<String, Object> value2Map =
+        ObjectCaster.castObjectToStringObjectMap(valueMapToMerge);
     mapToMergeInto.put(
         key, union(value1Map, value2Map, map1IsDefault, keypath, conflicts, conflictResolutions));
   }

--- a/library/src/test/java/SpecTreeFiltererTest.java
+++ b/library/src/test/java/SpecTreeFiltererTest.java
@@ -1,0 +1,216 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import org.junit.jupiter.api.Test;
+
+class SpecTreeFiltererTest {
+  @Test
+  void filter_withSpecificPath_succeeds()
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException,
+          AllUnmatchedFilterException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    FilterCriteria filterCriteria = FilterCriteria.builder().pathRegex("/pets/\\{petId\\}").build();
+
+    var listOfFilterCriteria = new ArrayList<FilterCriteria>();
+    listOfFilterCriteria.add(filterCriteria);
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithSpecificPath.yaml");
+
+    var actual = SpecTreeFilterer.filter(map1, listOfFilterCriteria);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withSpecificOperations_succeeds()
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException,
+          AllUnmatchedFilterException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    var operations = new ArrayList<String>();
+    operations.add("post");
+    operations.add("PATCH");
+
+    FilterCriteria filterCriteria = FilterCriteria.builder().operations(operations).build();
+
+    var listOfFilterCriteria = new ArrayList<FilterCriteria>();
+    listOfFilterCriteria.add(filterCriteria);
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithSpecificOperations.yaml");
+    var actual = SpecTreeFilterer.filter(map1, listOfFilterCriteria);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withRemovableTags_succeeds()
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException,
+          AllUnmatchedFilterException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    var removableTags = new ArrayList<String>();
+    removableTags.add("public");
+
+    FilterCriteria filterCriteria = FilterCriteria.builder().removableTags(removableTags).build();
+
+    var listOfFilterCriteria = new ArrayList<FilterCriteria>();
+    listOfFilterCriteria.add(filterCriteria);
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithPublicTags.yaml");
+
+    var actual = SpecTreeFilterer.filter(map1, listOfFilterCriteria);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withMultipleFilterCriteria_succeeds()
+      throws FileNotFoundException, UnionConflictException, AllUnmatchedFilterException,
+          UnexpectedTypeException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    var tags = new ArrayList<String>();
+    tags.add("pets");
+
+    FilterCriteria filterCriteria1 = FilterCriteria.builder().tags(tags).build();
+
+    var operations = new ArrayList<String>();
+    operations.add("get");
+
+    FilterCriteria filterCriteria2 =
+        FilterCriteria.builder().operations(operations).pathRegex("/pets.*").build();
+
+    var listOfFilterCriteria = new ArrayList<FilterCriteria>();
+    listOfFilterCriteria.add(filterCriteria1);
+    listOfFilterCriteria.add(filterCriteria2);
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithAllFilterCriteria.yaml");
+    var actual = SpecTreeFilterer.filter(map1, listOfFilterCriteria);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withUnselectedFilterCriteria_returnsOriginalSpec()
+      throws FileNotFoundException, UnionConflictException, AllUnmatchedFilterException,
+          UnexpectedTypeException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    FilterCriteria filterCriteria = FilterCriteria.builder().build();
+
+    var listOfFilterCriteria = new ArrayList<FilterCriteria>();
+    listOfFilterCriteria.add(filterCriteria);
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+    var actual = SpecTreeFilterer.filter(map1, listOfFilterCriteria);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withPathsThatWouldHaveNestedComponents_returnsComponentDependencyTree()
+      throws FileNotFoundException, UnionConflictException, AllUnmatchedFilterException,
+          UnexpectedTypeException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    var operations = new ArrayList<String>();
+    operations.add("get");
+
+    FilterCriteria filterCriteria =
+        FilterCriteria.builder().operations(operations).pathRegex("/pets").build();
+
+    var listOfFilterCriteria = new ArrayList<FilterCriteria>();
+    listOfFilterCriteria.add(filterCriteria);
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithOnlyPetsGet.yaml");
+
+    var actual = SpecTreeFilterer.filter(map1, listOfFilterCriteria);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withOnlyPathsThatDoNotHaveRefs_removesAllComponents()
+      throws FileNotFoundException, UnionConflictException, AllUnmatchedFilterException,
+      UnexpectedTypeException {
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    FilterCriteria filterCriteria =
+        FilterCriteria.builder().pathRegex("/path/with/no/refs").build();
+
+    var listOfFilterCriteria = new ArrayList<FilterCriteria>();
+    listOfFilterCriteria.add(filterCriteria);
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithSpecificPathNoRefs.yaml");
+
+    var actual = SpecTreeFilterer.filter(map1, listOfFilterCriteria);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withAllUnmatchedOrEmptyFilterCriteriaList_throws() throws FileNotFoundException {
+    var specTreeFilterer = new SpecTreeFilterer();
+
+    LinkedHashMap<String, Object> map1 =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    var filterCriteriaEmptyList = new ArrayList<FilterCriteria>();
+
+    LinkedHashMap<String, Object> expected =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithPublicTags.yaml");
+
+    assertThrows(
+        AllUnmatchedFilterException.class,
+        () -> SpecTreeFilterer.filter(map1, filterCriteriaEmptyList));
+  }
+}


### PR DESCRIPTION
NOTE: this PR is part of a series of upcoming PRs and as such, some code will be dependent on code in other branches. Breaking up into multiple PRs was done for reviewer ease.

- [x] 100% test coverage. Examples of usage shown in tests.
- [x] from the design proposal greendoc, implement filtering based on FilterCriteria which includes:
  - [x] tags (by disjunction) (e.g. pets)
  - [x] special "removable tags" which will be removed from the output spec. (e.g. INTERNAL, EXTERNAL) Please see greendoc for more details
  - [x] endpoint path regular expressions (e.g. /pet/.* or /pet/\\\\{id\\\\}/groom)
  - [x] operations (e.g. GET, PUT)
  - [x] any other permutation of the above properties, which can be batched into one FilterCriteria object
- [x] user can provide a list of such FilterCriteria, where we will return the union of the result of each FilterCriteria

component selection algorithm will be provided in an upcoming PR.