### PR TITLE
[FILTERING STEP 2] implement component ref selection class

### DIFF
--- a/library/src/main/java/SpecTreeComponentSelector.java
+++ b/library/src/main/java/SpecTreeComponentSelector.java
@@ -72,9 +72,6 @@ public class SpecTreeComponentSelector {
   /**
    * Return a formatted version the ref. For example, "#/components/schemas/Pet" would be formatted
    * to "[components, schemas, Pet]"
-   *
-   * @param value
-   * @return
    */
   private static String processRefKeyPath(Object value) {
     String refToProcess = (String) value;

--- a/library/src/main/java/SpecTreeComponentSelector.java
+++ b/library/src/main/java/SpecTreeComponentSelector.java
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;

--- a/library/src/main/java/SpecTreeComponentSelector.java
+++ b/library/src/main/java/SpecTreeComponentSelector.java
@@ -1,0 +1,102 @@
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Stack;
+
+public class SpecTreeComponentSelector {
+
+  /**
+   * Given a spec tree, returns only the relevant component refs for the paths present.
+   *
+   * @param spec a spec tree, which has typically been already filtered and might have unnecessary
+   *     components
+   * @return the components which are relevant to paths in {@code spec}
+   */
+  public static LinkedHashMap<String, Object> getRelevantComponents(
+      LinkedHashMap<String, Object> spec) throws UnionConflictException, UnexpectedTypeException {
+
+    var keypaths = new HashSet<String>();
+    addRefsInSubtreeToKeypaths(
+        ObjectCaster.castObjectToStringObjectMap(spec.get("paths")), keypaths);
+
+    var outputComponents = new LinkedHashMap<String, Object>();
+
+    int size = 0;
+    // as soon as keypaths.size() == size, terminate because no new refs need to be looked for.
+    while (keypaths.size() != size) {
+      size = keypaths.size();
+
+      LinkedHashMap<String, Object> relevantComponents =
+          expandComponentTree(spec, keypaths, new Stack<String>());
+      SpecTreesUnionizer.union(outputComponents, relevantComponents);
+    }
+
+    return outputComponents;
+  }
+
+  private static void addRefsInSubtreeToKeypaths(
+      LinkedHashMap<String, Object> paths, HashSet<String> refKeypaths) {
+    for (Map.Entry<String, Object> entry : paths.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+      if (key.equals("$ref")) {
+        String processedRefKeyPath = processRefKeyPath(value);
+        if (!processedRefKeyPath.isEmpty()) {
+          refKeypaths.add(processedRefKeyPath);
+        }
+      } else if (TypeChecker.isObjectMap(value)) {
+        LinkedHashMap<String, Object> subtreeMap = ObjectCaster.castObjectToStringObjectMap(value);
+        addRefsInSubtreeToKeypaths(subtreeMap, refKeypaths);
+      }
+    }
+  }
+
+  private static String processRefKeyPath(Object value) {
+    String refToProcess = (String) value;
+    if (refToProcess.substring(0, 1).equals("#")) {
+      // ignore the first two characters (#/)
+      return Arrays.asList(refToProcess.substring(2).split("/")).toString();
+    } else {
+      return "";
+    }
+  }
+
+  private static LinkedHashMap<String, Object> expandComponentTree(
+      LinkedHashMap<String, Object> components, HashSet<String> keypaths, Stack<String> keypath) {
+
+    var outputForThisLevel = new LinkedHashMap<String, Object>();
+
+    for (Map.Entry<String, Object> entry : components.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+
+      keypath.push(key);
+
+      if (keypaths.contains(keypath.toString())) {
+        // add this subtree
+        if (TypeChecker.isObjectMap(value)) {
+          LinkedHashMap<String, Object> subtreeMap =
+              ObjectCaster.castObjectToStringObjectMap(value);
+          addRefsInSubtreeToKeypaths(subtreeMap, keypaths);
+          outputForThisLevel.put(key, subtreeMap);
+        }
+      } else {
+        if (TypeChecker.isObjectMap(value)) {
+          LinkedHashMap<String, Object> subtreeMap =
+              ObjectCaster.castObjectToStringObjectMap(value);
+          LinkedHashMap<String, Object> outputForSubtree =
+              expandComponentTree(subtreeMap, keypaths, keypath);
+
+          if (!outputForSubtree.isEmpty()) {
+            outputForThisLevel.put(key, outputForSubtree);
+          }
+        }
+      }
+
+      keypath.pop();
+    }
+
+    return outputForThisLevel;
+  }
+}

--- a/library/src/main/java/SpecTreeComponentSelector.java
+++ b/library/src/main/java/SpecTreeComponentSelector.java
@@ -51,9 +51,10 @@ public class SpecTreeComponentSelector {
     return outputComponents;
   }
 
+  /** Add all the refs in this subtree to {@code refKeyPaths}. */
   private static void addRefsInSubtreeToKeypaths(
-      LinkedHashMap<String, Object> paths, HashSet<String> refKeypaths) {
-    for (Map.Entry<String, Object> entry : paths.entrySet()) {
+      LinkedHashMap<String, Object> subtree, HashSet<String> refKeypaths) {
+    for (Map.Entry<String, Object> entry : subtree.entrySet()) {
       String key = entry.getKey();
       Object value = entry.getValue();
       if (key.equals("$ref")) {
@@ -68,6 +69,13 @@ public class SpecTreeComponentSelector {
     }
   }
 
+  /**
+   * Return a formatted version the ref. For example, "#/components/schemas/Pet" would be formatted
+   * to "[components, schemas, Pet]"
+   *
+   * @param value
+   * @return
+   */
   private static String processRefKeyPath(Object value) {
     String refToProcess = (String) value;
     if (refToProcess.substring(0, 1).equals("#")) {
@@ -78,6 +86,10 @@ public class SpecTreeComponentSelector {
     }
   }
 
+  /**
+   * Finds all components which match those in {@code keypaths} and outputs them. Also, add all refs
+   * which components are dependent on to {@code keypaths}.
+   */
   private static LinkedHashMap<String, Object> expandComponentTree(
       LinkedHashMap<String, Object> components, HashSet<String> keypaths, Stack<String> keypath) {
 

--- a/library/src/test/java/SpecTreeComponentSelectorTest.java
+++ b/library/src/test/java/SpecTreeComponentSelectorTest.java
@@ -76,8 +76,7 @@ class SpecTreeComponentSelectorTest {
         YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
             "src/test/resources/filtering/componentSelectionDeeplyNestedRelevantComponents.yaml");
 
-    var actualComponents =
-        SpecTreeComponentSelector.getRelevantComponents(originalSpec);
+    var actualComponents = SpecTreeComponentSelector.getRelevantComponents(originalSpec);
 
     assertThat(actualComponents).isEqualTo(expectedComponents);
   }

--- a/library/src/test/java/SpecTreeComponentSelectorTest.java
+++ b/library/src/test/java/SpecTreeComponentSelectorTest.java
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.FileNotFoundException;
+import java.util.LinkedHashMap;
+import org.junit.jupiter.api.Test;
+
+class SpecTreeComponentSelectorTest {
+  @Test
+  void getRelevantComponents_withoutNestedComponents_succeeds()
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
+    LinkedHashMap<String, Object> originalSpec =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    LinkedHashMap<String, Object> filteredSpec =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithSpecificPath.yaml");
+
+    LinkedHashMap<String, Object> expectedComponents =
+        ObjectCaster.castObjectToStringObjectMap(filteredSpec.get("components"));
+
+    filteredSpec.put("components", originalSpec.get("components"));
+
+    var actualComponents =
+        SpecTreeComponentSelector.getRelevantComponents(filteredSpec).get("components");
+
+    assertThat(actualComponents).isEqualTo(expectedComponents);
+  }
+
+  @Test
+  void getRelevantComponents_withOneLevelNestedComponents_succeeds()
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
+    LinkedHashMap<String, Object> originalSpec =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteringMonolithicSpec.yaml");
+
+    LinkedHashMap<String, Object> filteredSpec =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/filteredMonolithicSpecWithOnlyPetsGet.yaml");
+
+    LinkedHashMap<String, Object> expectedComponents =
+        ObjectCaster.castObjectToStringObjectMap(filteredSpec.get("components"));
+
+    filteredSpec.put("components", originalSpec.get("components"));
+
+    var actualComponents =
+        SpecTreeComponentSelector.getRelevantComponents(filteredSpec).get("components");
+
+    assertThat(actualComponents).isEqualTo(expectedComponents);
+  }
+
+  @Test
+  void getRelevantComponents_withThreeLevelNestedComponents_succeeds()
+      throws FileNotFoundException, UnionConflictException, UnexpectedTypeException {
+    LinkedHashMap<String, Object> originalSpec =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/componentSelectionDeeplyNestedOriginal.yaml");
+
+    LinkedHashMap<String, Object> expectedComponents =
+        YamlStringToSpecTreeConverter.convertYamlFileToSpecTree(
+            "src/test/resources/filtering/componentSelectionDeeplyNestedRelevantComponents.yaml");
+
+    var actualComponents =
+        SpecTreeComponentSelector.getRelevantComponents(originalSpec);
+
+    assertThat(actualComponents).isEqualTo(expectedComponents);
+  }
+}


### PR DESCRIPTION
NOTE: this PR is part of a series of upcoming PRs and as such, some code will be dependent on code in other branches. Breaking up into multiple PRs was done for reviewer ease.

- [x] 100% test coverage
- [x] from the design proposal greendoc, implementation of component selection, which is an optimization on filtering that only keeps the components which are relevant to the newly filtered spec in the component tree
- [x] handles deeply nested component refs, which form a graph to traverse.
- [x] used in the SpecTreeFilterer class