### PR TITLE
[FILTERING STEP 3] Library supports filtering -- implement filtering at the upper level

### DIFF
--- a/library/src/main/java/FilterCriteriaJson.java
+++ b/library/src/main/java/FilterCriteriaJson.java
@@ -23,8 +23,8 @@ import java.util.List;
  * Used with Jackson's ObjectMapper to deserialize single JSON objects representing filter criteria.
  */
 public class FilterCriteriaJson {
-  @JsonProperty("pathRegex")
-  public String pathRegex = "";
+  @JsonProperty("path")
+  public String path = "";
 
   @JsonProperty("tags")
   public List<String> tags = new ArrayList<String>();
@@ -35,11 +35,11 @@ public class FilterCriteriaJson {
   @JsonProperty("operations")
   public List<String> operations = new ArrayList<String>();
 
-  /** Used to set the pathRegex. In the case of null, it uses the default value, an empty string. */
-  @JsonSetter("pathRegex")
-  public void setPathRegex(String pathRegex) {
-    if (pathRegex != null) {
-      this.pathRegex = pathRegex;
+  /** Used to set the path. In the case of null, it uses the default value, an empty string. */
+  @JsonSetter("path")
+  public void setPath(String path) {
+    if (path != null) {
+      this.path = path;
     }
   }
 

--- a/library/src/main/java/FilterCriteriaJson.java
+++ b/library/src/main/java/FilterCriteriaJson.java
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import java.util.ArrayList;

--- a/library/src/main/java/FilterCriteriaJson.java
+++ b/library/src/main/java/FilterCriteriaJson.java
@@ -1,0 +1,58 @@
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Used with Jackson's ObjectMapper to deserialize single JSON objects representing filter criteria.
+ */
+public class FilterCriteriaJson {
+  @JsonProperty("pathRegex")
+  public String pathRegex = "";
+
+  @JsonProperty("tags")
+  public List<String> tags = new ArrayList<String>();
+
+  @JsonProperty("removableTags")
+  public List<String> removableTags = new ArrayList<String>();
+
+  @JsonProperty("operations")
+  public List<String> operations = new ArrayList<String>();
+
+  /** Used to set the pathRegex. In the case of null, it uses the default value, an empty string. */
+  @JsonSetter("pathRegex")
+  public void setPathRegex(String pathRegex) {
+    if (pathRegex != null) {
+      this.pathRegex = pathRegex;
+    }
+  }
+
+  /** Used to set the tags list. In the case of null, it uses the default value, an empty list. */
+  @JsonSetter("tags")
+  public void setTags(List<String> tags) {
+    if (tags != null) {
+      this.tags = tags;
+    }
+  }
+
+  /**
+   * Used to set the removableTags list. In the case of null, it uses the default value, an empty
+   * list.
+   */
+  @JsonSetter("removableTags")
+  public void setRemovableTags(List<String> removableTags) {
+    if (removableTags != null) {
+      this.removableTags = removableTags;
+    }
+  }
+
+  /**
+   * Used to set the operations list. In the case of null, it uses the default value, an empty list.
+   */
+  @JsonSetter("operations")
+  public void setOperations(List<String> operations) {
+    if (operations != null) {
+      this.operations = operations;
+    }
+  }
+}

--- a/library/src/main/java/FilterOptions.java
+++ b/library/src/main/java/FilterOptions.java
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import com.google.auto.value.AutoValue;
+
+/** Used to provide additional parameters when calling filter functions of the SpecMath class. */
+@AutoValue
+public abstract class FilterOptions {
+  public static Builder builder() {
+    return new AutoValue_FilterOptions.Builder().defaults("");
+  }
+
+  public abstract String defaults();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder defaults(String defaults);
+
+    public abstract FilterOptions build();
+  }
+}

--- a/library/src/main/java/SpecMath.java
+++ b/library/src/main/java/SpecMath.java
@@ -144,7 +144,7 @@ public class SpecMath {
       listOfFilterCriteria.add(
           FilterCriteria.builder()
               .operations(filterCriteriaJson.operations)
-              .pathRegex(filterCriteriaJson.pathRegex)
+              .path(filterCriteriaJson.path)
               .removableTags(filterCriteriaJson.removableTags)
               .tags(filterCriteriaJson.tags)
               .build());

--- a/library/src/main/java/SpecTreesUnionizer.java
+++ b/library/src/main/java/SpecTreesUnionizer.java
@@ -187,13 +187,14 @@ public class SpecTreesUnionizer {
             valueOfMapToMerge,
             value1);
       } else if (TypeChecker.isObjectList(value1)
-          && TypeChecker.isObjectList(valueOfMapToMerge)
-          && !mapToMergeIntoIsDefault) {
-        List<Object> output =
-            ListUtils.listUnion(
-                ObjectCaster.castObjectToListOfObjects(value1),
-                ObjectCaster.castObjectToListOfObjects(valueOfMapToMerge));
-        mapToMergeInto.put(key, output);
+          && TypeChecker.isObjectList(valueOfMapToMerge)) {
+        if (!mapToMergeIntoIsDefault){
+          List<Object> output =
+              ListUtils.listUnion(
+                  ObjectCaster.castObjectToListOfObjects(value1),
+                  ObjectCaster.castObjectToListOfObjects(valueOfMapToMerge));
+          mapToMergeInto.put(key, output);
+        }
       } else if (TypeChecker.isObjectPrimitive(value1)
           && TypeChecker.isObjectPrimitive(valueOfMapToMerge)) {
         processUnequalLeafNodes(

--- a/library/src/main/java/SpecTreesUnionizer.java
+++ b/library/src/main/java/SpecTreesUnionizer.java
@@ -152,8 +152,14 @@ public class SpecTreesUnionizer {
       keypath.push(keyOfMapToMerge);
 
       if (mapToMergeInto.containsKey(keyOfMapToMerge)) {
-        processSubtreesWithSameKey(mapToMergeInto, mapToMergeIntoIsDefault, keypath, conflicts,
-            conflictResolutions, keyOfMapToMerge, valueOfMapToMerge);
+        processSubtreesWithSameKey(
+            mapToMergeInto,
+            mapToMergeIntoIsDefault,
+            keypath,
+            conflicts,
+            conflictResolutions,
+            keyOfMapToMerge,
+            valueOfMapToMerge);
 
       } else {
         // mapToMerge contains a key which mapToMergeInto does not have, so just add the entire
@@ -168,49 +174,61 @@ public class SpecTreesUnionizer {
     return mapToMergeInto;
   }
 
-  private static void processSubtreesWithSameKey(LinkedHashMap<String, Object> mapToMergeInto,
-      boolean mapToMergeIntoIsDefault, Stack<String> keypath, ArrayList<Conflict> conflicts,
-      HashMap<String, Object> conflictResolutions, String key, Object valueOfMapToMerge)
+  private static void processSubtreesWithSameKey(
+      LinkedHashMap<String, Object> mapToMergeInto,
+      boolean mapToMergeIntoIsDefault,
+      Stack<String> keypath,
+      ArrayList<Conflict> conflicts,
+      HashMap<String, Object> conflictResolutions,
+      String key,
+      Object valueOfMapToMerge)
       throws UnexpectedTypeException {
     Object value1 = mapToMergeInto.get(key);
 
-    if (!value1.equals(valueOfMapToMerge)) {
-      if (TypeChecker.isObjectMap(value1) && TypeChecker.isObjectMap((valueOfMapToMerge))) {
-        // We have two maps which contain the same key, add the key and process maps further.
-        processUnequalSubtrees(
-            mapToMergeInto,
-            mapToMergeIntoIsDefault,
-            keypath,
-            conflicts,
-            conflictResolutions,
-            key,
-            valueOfMapToMerge,
-            value1);
-      } else if (TypeChecker.isObjectList(value1)
-          && TypeChecker.isObjectList(valueOfMapToMerge)) {
-        if (!mapToMergeIntoIsDefault){
-          List<Object> output =
-              ListUtils.listUnion(
-                  ObjectCaster.castObjectToListOfObjects(value1),
-                  ObjectCaster.castObjectToListOfObjects(valueOfMapToMerge));
-          mapToMergeInto.put(key, output);
-        }
-      } else if (TypeChecker.isObjectPrimitive(value1)
-          && TypeChecker.isObjectPrimitive(valueOfMapToMerge)) {
-        processUnequalLeafNodes(
-            mapToMergeInto,
-            key,
-            value1,
-            valueOfMapToMerge,
-            mapToMergeIntoIsDefault,
-            keypath,
-            conflicts,
-            conflictResolutions);
-      } else {
-        // Either an unexpected type was met, or one map had a different type (primitive, map,
-        // list) as a value compared to the other.
-        throw new UnexpectedTypeException("Unexpected Data During Union");
-      }
+    if (value1.equals(valueOfMapToMerge)) {
+      return;
+    }
+
+    if (TypeChecker.isObjectMap(value1) && TypeChecker.isObjectMap((valueOfMapToMerge))) {
+      // We have two maps which contain the same key, add the key and process maps further.
+      processUnequalSubtrees(
+          mapToMergeInto,
+          mapToMergeIntoIsDefault,
+          keypath,
+          conflicts,
+          conflictResolutions,
+          key,
+          valueOfMapToMerge,
+          value1);
+    } else if (TypeChecker.isObjectList(value1) && TypeChecker.isObjectList(valueOfMapToMerge)) {
+      processUnequalListNodes(mapToMergeInto, mapToMergeIntoIsDefault, key, valueOfMapToMerge,
+          value1);
+    } else if (TypeChecker.isObjectPrimitive(value1)
+        && TypeChecker.isObjectPrimitive(valueOfMapToMerge)) {
+      processUnequalLeafNodes(
+          mapToMergeInto,
+          key,
+          value1,
+          valueOfMapToMerge,
+          mapToMergeIntoIsDefault,
+          keypath,
+          conflicts,
+          conflictResolutions);
+    } else {
+      // Either an unexpected type was met, or one map had a different type (primitive, map,
+      // list) as a value compared to the other.
+      throw new UnexpectedTypeException("Unexpected Data During Union");
+    }
+  }
+
+  private static void processUnequalListNodes(LinkedHashMap<String, Object> mapToMergeInto,
+      boolean mapToMergeIntoIsDefault, String key, Object valueOfMapToMerge, Object value1) {
+    if (!mapToMergeIntoIsDefault) {
+      List<Object> output =
+          ListUtils.listUnion(
+              ObjectCaster.castObjectToListOfObjects(value1),
+              ObjectCaster.castObjectToListOfObjects(valueOfMapToMerge));
+      mapToMergeInto.put(key, output);
     }
   }
 
@@ -234,10 +252,10 @@ public class SpecTreesUnionizer {
       Object valueMapToMerge,
       Object valueMapToMergeInto)
       throws UnexpectedTypeException {
-    LinkedHashMap<String, Object> value1Map = ObjectCaster.castObjectToStringObjectMap(
-        valueMapToMergeInto);
-    LinkedHashMap<String, Object> value2Map = ObjectCaster.castObjectToStringObjectMap(
-        valueMapToMerge);
+    LinkedHashMap<String, Object> value1Map =
+        ObjectCaster.castObjectToStringObjectMap(valueMapToMergeInto);
+    LinkedHashMap<String, Object> value2Map =
+        ObjectCaster.castObjectToStringObjectMap(valueMapToMerge);
     mapToMergeInto.put(
         key, union(value1Map, value2Map, map1IsDefault, keypath, conflicts, conflictResolutions));
   }

--- a/library/src/test/java/SpecMathTest.java
+++ b/library/src/test/java/SpecMathTest.java
@@ -76,7 +76,8 @@ class SpecMathTest {
   }
 
   @Test
-  void union_withDefaults_succeeds() throws IOException, UnionConflictException, UnexpectedTypeException {
+  void union_withDefaults_succeeds()
+      throws IOException, UnionConflictException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/elgoogBilling.yaml"));
     String defaults = Files.readString(Path.of("src/test/resources/elgoogMetadata.yaml"));
@@ -163,5 +164,102 @@ class SpecMathTest {
         Files.readString(Path.of("src/test/resources/elgoogBillingOverlayedWithMetadata.yaml"));
 
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withSpecificPath_succeeds()
+      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
+    String specString =
+        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
+    String filterCriteria =
+        Files.readString(Path.of("src/test/resources/filtering/specificPathFilterCriteria.json"));
+    String actual = SpecMath.filter(specString, filterCriteria);
+    String expected =
+        Files.readString(
+            Path.of("src/test/resources/filtering/filteredMonolithicSpecWithSpecificPath.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withSpecificOperations_succeeds()
+      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
+    String specString =
+        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
+    String filterCriteria =
+        Files.readString(Path.of("src/test/resources/filtering/specificOperationsFilterCriteria.json"));
+    String actual = SpecMath.filter(specString, filterCriteria);
+    String expected =
+        Files.readString(
+            Path.of(
+                "src/test/resources/filtering/filteredMonolithicSpecWithSpecificOperations.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withRemovableTags_succeeds()
+      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
+    String specString =
+        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
+    String filterCriteria =
+        Files.readString(Path.of("src/test/resources/filtering/publicTagsFilterCriteria.json"));
+    String actual = SpecMath.filter(specString, filterCriteria);
+    String expected =
+        Files.readString(
+            Path.of("src/test/resources/filtering/filteredMonolithicSpecWithPublicTags.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withFilterCriteriaAndOptions_succeeds()
+      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
+    String specString =
+        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
+    String filterCriteria =
+        Files.readString(Path.of("src/test/resources/filtering/allFilterCriteria.json"));
+    String defaults = Files.readString(Path.of("src/test/resources/elgoogMetadata.yaml"));
+    FilterOptions filterOptions = FilterOptions.builder().defaults(defaults).build();
+    String actual = SpecMath.filter(specString, filterCriteria, filterOptions);
+    String expected =
+        Files.readString(
+            Path.of(
+                "src/test/resources/filtering/filteredMonolithicSpecWithOptionsAndAllFilterCriteria.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withMultipleFilterCriteria_succeeds()
+      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
+    String specString =
+        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
+    String filterCriteria =
+        Files.readString(Path.of("src/test/resources/filtering/allFilterCriteria.json"));
+    String actual = SpecMath.filter(specString, filterCriteria);
+    String expected =
+        Files.readString(
+            Path.of(
+                "src/test/resources/filtering/filteredMonolithicSpecWithAllFilterCriteria.yaml"));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filter_withAllUnmatchedOrEmptyFilterCriteria_throws()
+      throws IOException, AllUnmatchedFilterException {
+    String specString =
+        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
+    String filterCriteriaUnmatched =
+        Files.readString(Path.of("src/test/resources/filtering/unmatchedFilterCriteria.json"));
+    String filterCriteriaEmptyList = "[]";
+
+    assertThrows(
+        AllUnmatchedFilterException.class,
+        () -> SpecMath.filter(specString, filterCriteriaUnmatched));
+    assertThrows(
+        AllUnmatchedFilterException.class,
+        () -> SpecMath.filter(specString, filterCriteriaEmptyList));
   }
 }

--- a/library/src/test/java/SpecMathTest.java
+++ b/library/src/test/java/SpecMathTest.java
@@ -76,8 +76,7 @@ class SpecMathTest {
   }
 
   @Test
-  void union_withDefaults_succeeds()
-      throws IOException, UnionConflictException, UnexpectedTypeException {
+  void union_withDefaults_succeeds() throws IOException, UnionConflictException, UnexpectedTypeException {
     String spec1String = Files.readString(Path.of("src/test/resources/elgoogMarketing.yaml"));
     String spec2String = Files.readString(Path.of("src/test/resources/elgoogBilling.yaml"));
     String defaults = Files.readString(Path.of("src/test/resources/elgoogMetadata.yaml"));
@@ -164,102 +163,5 @@ class SpecMathTest {
         Files.readString(Path.of("src/test/resources/elgoogBillingOverlayedWithMetadata.yaml"));
 
     assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void filter_withSpecificPath_succeeds()
-      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
-    String specString =
-        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
-    String filterCriteria =
-        Files.readString(Path.of("src/test/resources/filtering/specificPathFilterCriteria.json"));
-    String actual = SpecMath.filter(specString, filterCriteria);
-    String expected =
-        Files.readString(
-            Path.of("src/test/resources/filtering/filteredMonolithicSpecWithSpecificPath.yaml"));
-
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void filter_withSpecificOperations_succeeds()
-      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
-    String specString =
-        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
-    String filterCriteria =
-        Files.readString(Path.of("src/test/resources/filtering/specificOperationsFilterCriteria.json"));
-    String actual = SpecMath.filter(specString, filterCriteria);
-    String expected =
-        Files.readString(
-            Path.of(
-                "src/test/resources/filtering/filteredMonolithicSpecWithSpecificOperations.yaml"));
-
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void filter_withRemovableTags_succeeds()
-      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
-    String specString =
-        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
-    String filterCriteria =
-        Files.readString(Path.of("src/test/resources/filtering/publicTagsFilterCriteria.json"));
-    String actual = SpecMath.filter(specString, filterCriteria);
-    String expected =
-        Files.readString(
-            Path.of("src/test/resources/filtering/filteredMonolithicSpecWithPublicTags.yaml"));
-
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void filter_withFilterCriteriaAndOptions_succeeds()
-      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
-    String specString =
-        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
-    String filterCriteria =
-        Files.readString(Path.of("src/test/resources/filtering/allFilterCriteria.json"));
-    String defaults = Files.readString(Path.of("src/test/resources/elgoogMetadata.yaml"));
-    FilterOptions filterOptions = FilterOptions.builder().defaults(defaults).build();
-    String actual = SpecMath.filter(specString, filterCriteria, filterOptions);
-    String expected =
-        Files.readString(
-            Path.of(
-                "src/test/resources/filtering/filteredMonolithicSpecWithOptionsAndAllFilterCriteria.yaml"));
-
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void filter_withMultipleFilterCriteria_succeeds()
-      throws IOException, AllUnmatchedFilterException, UnionConflictException, UnexpectedTypeException {
-    String specString =
-        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
-    String filterCriteria =
-        Files.readString(Path.of("src/test/resources/filtering/allFilterCriteria.json"));
-    String actual = SpecMath.filter(specString, filterCriteria);
-    String expected =
-        Files.readString(
-            Path.of(
-                "src/test/resources/filtering/filteredMonolithicSpecWithAllFilterCriteria.yaml"));
-
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void filter_withAllUnmatchedOrEmptyFilterCriteria_throws()
-      throws IOException, AllUnmatchedFilterException {
-    String specString =
-        Files.readString(Path.of("src/test/resources/filtering/filteringMonolithicSpec.yaml"));
-    String filterCriteriaUnmatched =
-        Files.readString(Path.of("src/test/resources/filtering/unmatchedFilterCriteria.json"));
-    String filterCriteriaEmptyList = "[]";
-
-    assertThrows(
-        AllUnmatchedFilterException.class,
-        () -> SpecMath.filter(specString, filterCriteriaUnmatched));
-    assertThrows(
-        AllUnmatchedFilterException.class,
-        () -> SpecMath.filter(specString, filterCriteriaEmptyList));
   }
 }


### PR DESCRIPTION
NOTE: this PR is part of a series of upcoming PRs and as such, some code will be dependent on code in other branches. Breaking up into multiple PRs was done for reviewer ease.

- [x] 100% test coverage, which provides example usages of the filtering functions class. The tests are located in this PR: https://github.com/googleinterns/spec-math/pull/21
- [x] SpecMath can perform filter on an OpenAPI spec represented as a YAML string and a list of filter criteria represented as JSON string. Includes optimizations such as including only the relevant component refs in the ref tree (https://github.com/googleinterns/spec-math/pull/24). Please see https://github.com/googleinterns/spec-math/pull/23 for details about what's currently supported, or visit the greendoc.
- [x] Also supports providing special options with FilterOptions using the builder pattern, which are applied during the filter.
- [x] Special options with FilterOptions currently provide support for applying defaults to a filtered result spec.

