### PR TITLE
Create root level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ than the input specs. This is why overlaying functionality will also be supporte
 be applied using a “default file” which contains metadata about the final API product that is
 produced from Spec Math operations. For example, if a company wishes to build a web
 application using filtered pieces of their unified API, the original spec will no longer have an
-accurate “info: title” key path. The overlay will contain something like "info: title: Company Web
-Application” which will be applied to the resultant specification.
+accurate `info: title` key path. The overlay will contain something like `info: title: Company Web
+Application` which will be applied to the resultant specification.
 
 ### Overview
 
@@ -93,7 +93,7 @@ a conflict in the `info: license: name` key path. To resolve this, the user can 
 file as an overlay. In cases where the overlay cannot resolve the conflict, the conflicting key
 paths will be reported back. The user can then resolve the conflicts by either:
 
-- using a conflict resolution file ([sample](library/src/test/resources/conflictMerged.yaml) passed in as a parameter to the union,
+- using a conflict resolution file ([sample](library/src/test/resources/conflictMerged.yaml)) passed in as a parameter to the union,
 - manually resolving the specs by removing the conflict
 - or updating the defaults file.
 
@@ -113,7 +113,7 @@ of features from A according to F. A filter file contains a list of Filter Crite
 Only the component references from A which are relevant to B will be included.
 
 Below is a list of properties which can be added to a Filter Criteria Object. A filter file F is a list of
-Filter Criteria Objects. For examples of F, please see the JSON files in the [filtering tests resources directory](library/src/test/resources/filtering)
+Filter Criteria Objects. For examples of F, please see the JSON files in the [filtering tests resources directory](library/src/test/resources/filtering).
 
 - **FILTER BY TAGS**. The user can achieve fine-grained filtering functionality extremely
 easily by just adding specific tags to the spec. For example, the user could mark
@@ -131,14 +131,15 @@ filtering.
  as well as desired operations (e.g. get, put)
   - Paths are specified in the `path` property in the filter criteria
   - Operations are specified in the `operations` property in the filter criteria
-- **FILTER OPTIONS**. By default, when the user provides a list of filter criteria, all matches
-will be included. Future work includes the ability to provide an “exclude” option to filter criteria, which will exclude
-paths matching the criteria in the resultant spec.
-
+  
 In addition to a filter file, users can also specify other filtering “options” or “parameters”. Similar
 to the union operation, the API product which is represented by the result of a filter operation is
 quite different from the spec which was used to filter. Therefore, a useful option will be to
-provide metadata about the resultant spec.
+provide metadata about the resultant spec. 
+
+By default, when the user provides a list of filter criteria, all matches
+will be included. Future work includes the ability to provide an “exclude” option, which will exclude
+paths matching the criteria in the resultant spec.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ The requirements for union of multiple specs are still being determined.
 #### Overlay
 Overlay takes spec A along with a defaults file D ([sample](library/src/test/resources/metadata.yaml)) to modify spec A. D is a spec fragment
 which will be placed "on top" of spec A. 
-In the case of a collision, the defaults file takes priority. 
+In the case of a would-be collision, the defaults file takes priority. 
 An overlay operation is a specialized Union operation between A and D where D will always take priority.
-Therefore, Overlay operations will not have collisions (or union conflicts). 
+Therefore, Overlay operations will not have union conflicts. 
 
 #### Filter
 Filtering takes spec A along with a filter file F to create a new spec B which contains a subset

--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Spec Math
 ## Overview
-A platform for performing operations on OpenAPI specifications (specs). OpenAPI is the industry-standard
+Spec Math is a platform for performing operations on OpenAPI specifications. OpenAPI is the industry-standard
 format for machine-readable REST API descriptions.
 
-## Background
+## About this document
+This document contains an overview about Spec Math and this repository. For more specific documentation 
+and installation instructions, please look at the respective folder in the directory structure
+described below.
+
+## Directory structure
+- The `library` folder contains the "Spec Math Library", an implementation of Spec Math in Java. 
+- The `web` folder showcases an
+example usage of the Spec Math Library through an API which is connected to the frontend application in the
+`app` folder.
+
+## Spec Math Library
+
+### Background
 
 Specifications play a critical role in the API lifecycle. They can enforce a contract between client
 and server teams, easily generate documentation and client libraries, reduce the work of
@@ -12,42 +25,40 @@ Spec Math project aims to afford even more power to API developers who use the O
 specification. The Spec Math Library will enable them to do the following:
 
 - Merge two or more OpenAPI specifications into one.
-- Filter an OpenAPI specification based on specified criteria.
+- Filter an OpenAPI specification into a new one based on specified criteria.
 - Overlay an OpenAPI specification.
 - And more, discussed in the sections and examples below.
 
-Let's suppose there is a complex project with several teams, each responsible for developing different
+Let's suppose there is a complex project with several teams working on it. 
+Each team is responsible for developing different
 portions of an API. These teams might include marketing, inventory, analytics, and others. If all
-10 teams were to work off of the same specification, it could become an extremely long and
-unwieldy document. Then, if the company wants to expose a subset of functionality to specific
+teams were to work off of the same specification, it could become an extremely long and
+unwieldy document. Then, if the developers want to expose a subset of functionality to specific
 user groups and developer teams, they would perform a tedious, manual, and error-prone
-cherry-pick of features to add to a new spec. These are both examples of where Spec Math can
+cherry-pick of features to add to a new spec. These are both one of many where Spec Math can
 come to the rescue.
 
-### Union
+#### Union
 One feature of Spec Math is to merge two or more specs into one. The developers could
 then have each team working on their own APIs with their own respective specs. From there, the
 developers can leverage the Spec Math Library to create a unified spec to describe the APIs
-developed across all the teams. This could be very useful for generating documentation, but
-also as a prerequisite for another key feature of Spec Math: filtering.
+developed across all the teams.
 
-### Filter
+#### Filter
 The developers are now able to unify the specs across multiple teams using the union feature
 of the Spec Math Library. Now, though, providers want to give specific user groups and
 developer teams access to portions of the unified API. For example, the developers now want to
 create a public API with all of the API endpoints across all teams that do not require
-authentication. It would be a tedious and error-prone process to manually cherry-pick pieces of
+internal authentication. It would be a tedious and error-prone process to manually cherry-pick pieces of
 the unified API and paste them into a new public API spec.
-With filtering, the company can provide the unified spec, along with a list of filter criteria that
-they want to match. For example, they can tag public endpoints with a “public tag” and then
-apply filter. The Spec Math Library will then return an OpenAPI spec with just the relevant pieces
-of the unified API. The company would also be able to use filtering to develop customized API
-documentation for their web app team, for users who will only use or have access to a subset of
-the monolithic API functionality. This can be done all while allowing the federated teams to
-focus on their own portion of the API if Spec Math is used.
+With filtering, the developers can provide the unified spec, along with a list of filter criteria that
+they want to match, and get a new spec matching the criteria. For example, filtering would allow the developers
+to generate a new spec with only the "public" tagged operations.
 
-### Overlay
-In the case of both filtering and merging, the resultant spec represents a different API product
+#### Overlay
+Overlay allows developers to place OpenAPI spec fragments on top of existing specs.
+
+For example, in the case of both filtering and merging, the resultant spec represents a different API product
 than the input specs. This is why overlaying functionality will also be supported. An overlay can
 be applied using a “default file” which contains metadata about the final API product that is
 produced from Spec Math operations. For example, if a company wishes to build a web
@@ -55,19 +66,69 @@ application using filtered pieces of their unified API, the original spec will n
 accurate “info: title” key path. The overlay will contain something like "info: title: Company Web
 Application” which will be applied to the resultant specification.
 
-### Spec Math Library
-#### Features
+### Overview
 
-## Directory structure
-- The `library` folder contains the "Spec Math Library", an implementation of Spec Math in Java. 
-- The `web` folder showcases an
-example usage of the Spec Math Library through an API which is connected the frontend application in the
-`app` folder.
+This section provides a high-level overview of the capabilities of the Spec Math Library while
+also defining some other terminology. See the background section for a description of why
+some of these capabilities of Spec Math might be useful.
 
-## About this document
-This document contains an overview of the Spec Math platform. For more specific documentation 
-and installation instructions, please look at the respective folder in the directory structure
-described above.
+#### Operations
+##### Union
+
+##### Union Of Two Specs
+Union takes specs A and B to create a new spec C which contains A and B.
+A collision occurs when two YAML key paths have different primitive values. For example, if
+spec A had `info: license: name: MIT` and spec B had `info: license: name: GPL`, there would be
+a conflict in the `info: license: name` key path. To resolve this, the user can provide a defaults
+file as an overlay. In cases where the overlay cannot resolve the conflict, the conflicting key
+paths will be reported back. The user can then resolve the conflicts by either:
+
+- using a conflict resolution object passed in as a parameter to the union,
+- manually resolving the specs by removing the conflict
+- or updating the defaults file.
+
+##### Union Of Multiple Specs
+The requirements for union of multiple specs are still being determined. 
+
+#### Overlay
+Overlay takes spec A along with an overlay file O (sample here LINK) to modify spec A. O is a spec fragment
+which will be placed "on top" of spec A. 
+In the case of a collision, the overlay file takes priority. 
+An overlay operation is a specialized Union operation between A and O where O will always take priority.
+Therefore, Overlay operations will not have conflicts. 
+
+#### Filter
+Filtering takes spec A along with a filter file F to create a new spec B which contains a subset
+of features from A according to F. A filter file contains a list of Filter Criteria Objects, discussed below.
+Only the component references from A which are relevant to B will be included.
+
+- **FILTER BY TAGS**. The user can achieve fine-grained filtering functionality extremely
+easily by just adding specific tags to the spec. For example, the user could mark
+operations as “internal” or “external” and easily filter based on these tags.
+  - Users can provide a list of tags in the `tags` property of the filter criteria.
+   Only endpoints
+   which contain those tags will be
+kept in the resultant spec. 
+  - Users can specify certain tags with the `removableTags` property
+in the filter criteria, which will remove those tags in the resultant
+spec. That way, published spec docs wouldn’t contain
+these special tags which were only added to the spec for the purposes of
+filtering. 
+- **FILTER BY PATHS AND OPERATIONS**. The user can filter based on desired paths,
+ as well as desired operations (e.g. get, put)
+  - Paths are specified in the `path` property in the filter criteria
+  - Operations are specified in the `operations` property in the filter criteria
+- **FILTER OPTIONS**. By default, when the user provides a list of filter criteria, all matches
+will be included. Future work includes the ability to provide an “exclude” option to filter criteria, which will exclude
+paths matching the criteria in the resultant spec.
+
+Users can provide a list of objects which contain a path, an operation, or both.
+These paths and operations will be filtered on.
+
+In addition to Filter Criteria, there will also be other filtering “options” or “parameters”. Similar
+to the union operation, the API product which is represented by the result of a filter operation is
+quite different from the spec which was used to filter. Therefore, a useful option will be to
+provide metadata about the resultant spec.
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spec Math
 ## Overview
 Spec Math is a platform for performing operations on OpenAPI specifications. 
-[OpenAPI](https://github.com/OAI/OpenAPI-Specification) is the industry-standard
+[OpenAPI](https://github.com/OAI/OpenAPI-Specification) is an industry-standard
 format for machine-readable REST API descriptions.
 
 ## About this document
@@ -35,7 +35,7 @@ specification. The [Spec Math Library](library) will enable them to do the follo
 
 - Merge two (or more in a future update) OpenAPI specifications into one.
 - Filter an OpenAPI specification into a new spec based on specified criteria.
-- Overlay an OpenAPI specification.
+- Overlay an OpenAPI specification by superimposing partial specs with domain-specific annotations.
 - And more, discussed in the sections and examples below.
 
 While these features are currently supported in the [Spec Math Library](library), please
@@ -97,7 +97,7 @@ provided for some example usages of the operations discussed below. Each test co
 ##### Union Of Two Specs
 Union of two specs takes specs A and B along with an optional set of rules to create a new spec C which contains A and B.
 
-A collision occurs when two YAML key paths have different primitive values. For example, if
+A collision (or union conflict) occurs when two YAML key paths have different primitive values. For example, if
 spec A had `info: license: name: MIT` and spec B had `info: license: name: GPL`, there would be
 a conflict in the `info: license: name` key path. To resolve this, the user can provide a defaults
 file as an overlay. In cases where the overlay cannot resolve the conflict, the conflicting key
@@ -115,7 +115,7 @@ Overlay takes spec A along with a defaults file D ([sample](library/src/test/res
 which will be placed "on top" of spec A. 
 In the case of a collision, the defaults file takes priority. 
 An overlay operation is a specialized Union operation between A and D where D will always take priority.
-Therefore, Overlay operations will not have conflicts. 
+Therefore, Overlay operations will not have collisions (or union conflicts). 
 
 #### Filter
 Filtering takes spec A along with a filter file F to create a new spec B which contains a subset

--- a/README.md
+++ b/README.md
@@ -1,3 +1,74 @@
 # Spec Math
+## Overview
+A platform for performing operations on OpenAPI specifications (specs). OpenAPI is the industry-standard
+format for machine-readable REST API descriptions.
 
-A tool that merges OpenAPI Specifications.
+## Background
+
+Specifications play a critical role in the API lifecycle. They can enforce a contract between client
+and server teams, easily generate documentation and client libraries, reduce the work of
+creating a proxy for an existing service and much more. The
+Spec Math project aims to afford even more power to API developers who use the OpenAPI
+specification. The Spec Math Library will enable them to do the following:
+
+- Merge two or more OpenAPI specifications into one.
+- Filter an OpenAPI specification based on specified criteria.
+- Overlay an OpenAPI specification.
+- And more, discussed in the sections and examples below.
+
+Let's suppose there is a complex project with several teams, each responsible for developing different
+portions of an API. These teams might include marketing, inventory, analytics, and others. If all
+10 teams were to work off of the same specification, it could become an extremely long and
+unwieldy document. Then, if the company wants to expose a subset of functionality to specific
+user groups and developer teams, they would perform a tedious, manual, and error-prone
+cherry-pick of features to add to a new spec. These are both examples of where Spec Math can
+come to the rescue.
+
+### Union
+One feature of Spec Math is to merge two or more specs into one. The developers could
+then have each team working on their own APIs with their own respective specs. From there, the
+developers can leverage the Spec Math Library to create a unified spec to describe the APIs
+developed across all the teams. This could be very useful for generating documentation, but
+also as a prerequisite for another key feature of Spec Math: filtering.
+
+### Filter
+The developers are now able to unify the specs across multiple teams using the union feature
+of the Spec Math Library. Now, though, providers want to give specific user groups and
+developer teams access to portions of the unified API. For example, the developers now want to
+create a public API with all of the API endpoints across all teams that do not require
+authentication. It would be a tedious and error-prone process to manually cherry-pick pieces of
+the unified API and paste them into a new public API spec.
+With filtering, the company can provide the unified spec, along with a list of filter criteria that
+they want to match. For example, they can tag public endpoints with a “public tag” and then
+apply filter. The Spec Math Library will then return an OpenAPI spec with just the relevant pieces
+of the unified API. The company would also be able to use filtering to develop customized API
+documentation for their web app team, for users who will only use or have access to a subset of
+the monolithic API functionality. This can be done all while allowing the federated teams to
+focus on their own portion of the API if Spec Math is used.
+
+### Overlay
+In the case of both filtering and merging, the resultant spec represents a different API product
+than the input specs. This is why overlaying functionality will also be supported. An overlay can
+be applied using a “default file” which contains metadata about the final API product that is
+produced from Spec Math operations. For example, if a company wishes to build a web
+application using filtered pieces of their unified API, the original spec will no longer have an
+accurate “info: title” key path. The overlay will contain something like "info: title: Company Web
+Application” which will be applied to the resultant specification.
+
+### Spec Math Library
+#### Features
+
+## Directory structure
+- The `library` folder contains the "Spec Math Library", an implementation of Spec Math in Java. 
+- The `web` folder showcases an
+example usage of the Spec Math Library through an API which is connected the frontend application in the
+`app` folder.
+
+## About this document
+This document contains an overview of the Spec Math platform. For more specific documentation 
+and installation instructions, please look at the respective folder in the directory structure
+described above.
+
+## Copyright
+
+Copyright 2020, Google LLC.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ format for machine-readable REST API descriptions.
 This document contains an overview of this repository as well as a description of Spec Math.
 
 A goal of this document is to highlight the capabilities of Spec Math and
-describe its operations and functions. While this repository already contains
-a [Java implementation](library) of Spec Math, we hope that this document (along with the
-[Java implementation](library)) will provide
-enough information such that developers could also implement Spec Math in any language
-of their choosing. For more specific documentation and installation instructions, please look 
+describe its operations and functions so that you can determine if it might be useful to your project. 
+
+While this repository already contains a [Java implementation](library) of Spec Math, we acknowledge that
+your project might have different language needs and hope that this document (along with the
+[Java implementation](library)) will also provide
+enough information such that you could implement Spec Math in any language
+of your choosing. For more specific documentation and installation instructions, please look 
 at the respective folder in the directory structure
 described below.
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,19 @@ format for machine-readable REST API descriptions.
 ## About this document
 This document contains an overview of this repository as well as a description of Spec Math.
 
-A goal of this document is to highlight the capabilities of Spec Math as well as
-rigorously describe its operations and functions. While this repository already contains
-a [Java implementation](library) of Spec Math, we hope that this document will provide
+A goal of this document is to highlight the capabilities of Spec Math and
+describe its operations and functions. While this repository already contains
+a [Java implementation](library) of Spec Math, we hope that this document (along with the
+[Java implementation](library)) will provide
 enough information such that developers could also implement Spec Math in any language
-of their choosing. For more specific documentation and installation instructions, please look at the respective folder in the directory structure
+of their choosing. For more specific documentation and installation instructions, please look 
+at the respective folder in the directory structure
 described below.
 
 ## Directory structure
 - The [library](library) folder contains the "Spec Math Library", an implementation of Spec Math in Java.
-- The [web](web) folder showcases an
-example usage of the Spec Math Library through an API which is connected to the frontend application in the
+- The [web](web) folder showcases an example usage of the Spec Math Library through an API which is connected
+ to the frontend application in the
 [app](app) folder.
 
 ## Spec Math and the Spec Math Library
@@ -34,13 +36,19 @@ specification. The [Spec Math Library](library) will enable them to do the follo
 - Overlay an OpenAPI specification.
 - And more, discussed in the sections and examples below.
 
+While these features are currently supported in the [Spec Math Library](library), please
+note that "Spec Math" as a platform could theoretically support many other operations on OpenAPI specifications.
+Contributions of new features and operations are welcome!
+
+Below is a simple example of a use case of Spec Math.
+
 Let's suppose there is a complex project with several teams working on it. 
 Each team is responsible for developing different
 portions of an API. These teams might include marketing, inventory, analytics, and others. If all
 teams were to work off of the same specification, it could become an extremely long and
 unwieldy document. Then, if the developers want to expose a subset of functionality to specific
 user groups and developer teams, they would perform a tedious, manual, and error-prone
-cherry-pick of features to add to a new spec. These are some examples where Spec Math could
+cherry-pick of features to add to a new spec. These are some examples of where Spec Math could
 come to the rescue.
 
 #### Union

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spec Math
 ## Overview
-Spec Math is a platform for performing operations on OpenAPI specifications. OpenAPI is the industry-standard
+Spec Math is a platform for performing operations on OpenAPI specifications. [OpenAPI](https://github.com/OAI/OpenAPI-Specification) is the industry-standard
 format for machine-readable REST API descriptions.
 
 ## About this document

--- a/README.md
+++ b/README.md
@@ -5,30 +5,32 @@ Spec Math is a platform for performing operations on OpenAPI specifications.
 format for machine-readable REST API descriptions.
 
 ## About this document
-This document contains an overview about Spec Math and this repository. One of the goals of this document
-is to provide descriptions of Spec Math which, along with the [Java implementation in this repo](library)
- For more specific documentation 
-and installation instructions, please look at the respective folder in the directory structure
+This document contains an overview of this repository as well as a description of Spec Math.
+
+A goal of this document is to highlight the capabilities of Spec Math as well as
+rigorously describe its operations and functions. While this repository already contains
+a [Java implementation](library) of Spec Math, we hope that this document will provide
+enough information such that developers could also implement Spec Math in any language
+of their choosing. For more specific documentation and installation instructions, please look at the respective folder in the directory structure
 described below.
 
 ## Directory structure
-- The `library` folder contains the "Spec Math Library", an implementation of Spec Math in Java. 
-- The `web` folder showcases an
+- The [library](library) folder contains the "Spec Math Library", an implementation of Spec Math in Java.
+- The [web](web) folder showcases an
 example usage of the Spec Math Library through an API which is connected to the frontend application in the
-`app` folder.
+[app](app) folder.
 
-## Spec Math Library
+## Spec Math and the Spec Math Library
 
 ### Background
-
 Specifications play a critical role in the API lifecycle. They can enforce a contract between client
 and server teams, easily generate documentation and client libraries, reduce the work of
 creating a proxy for an existing service and much more. The
 Spec Math project aims to afford even more power to API developers who use the OpenAPI
-specification. The Spec Math Library will enable them to do the following:
+specification. The [Spec Math Library](library) will enable them to do the following:
 
-- Merge two or more OpenAPI specifications into one.
-- Filter an OpenAPI specification into a new one based on specified criteria.
+- Merge two (or more in a future update) OpenAPI specifications into one.
+- Filter an OpenAPI specification into a new spec based on specified criteria.
 - Overlay an OpenAPI specification.
 - And more, discussed in the sections and examples below.
 
@@ -38,13 +40,13 @@ portions of an API. These teams might include marketing, inventory, analytics, a
 teams were to work off of the same specification, it could become an extremely long and
 unwieldy document. Then, if the developers want to expose a subset of functionality to specific
 user groups and developer teams, they would perform a tedious, manual, and error-prone
-cherry-pick of features to add to a new spec. These are both one of many where Spec Math can
+cherry-pick of features to add to a new spec. These are some examples where Spec Math could
 come to the rescue.
 
 #### Union
 One feature of Spec Math is to merge two or more specs into one. The developers could
 then have each team working on their own APIs with their own respective specs. From there, the
-developers can leverage the Spec Math Library to create a unified spec to describe the APIs
+developers can leverage the [Spec Math Library](library) to create a unified spec to describe the APIs
 developed across all the teams.
 
 #### Filter
@@ -71,22 +73,27 @@ Application” which will be applied to the resultant specification.
 
 ### Overview
 
-This section provides a high-level overview of the capabilities of the Spec Math Library while
-also defining some other terminology. See the background section for a description of why
-some of these capabilities of Spec Math might be useful.
+This section provides descriptions of Spec Math operations. See the background section for an example of how
+some of these capabilities of Spec Math might be useful.   
+
+For additional specific examples of each operation described below, please take a look at the integration
+tests for the [Spec Math Library](library/src/test/java/org/specmath/library/SpecMathTest.java). Tests are
+provided for some example usages of the operations discussed below. Each test contains a sample input and output.
 
 #### Operations
+
 ##### Union
 
 ##### Union Of Two Specs
-Union takes specs A and B to create a new spec C which contains A and B.
+Union of two specs takes specs A and B along with an optional set of rules to create a new spec C which contains A and B.
+
 A collision occurs when two YAML key paths have different primitive values. For example, if
 spec A had `info: license: name: MIT` and spec B had `info: license: name: GPL`, there would be
 a conflict in the `info: license: name` key path. To resolve this, the user can provide a defaults
 file as an overlay. In cases where the overlay cannot resolve the conflict, the conflicting key
 paths will be reported back. The user can then resolve the conflicts by either:
 
-- using a conflict resolution object passed in as a parameter to the union,
+- using a conflict resolution file ([sample](library/src/test/resources/conflictMerged.yaml) passed in as a parameter to the union,
 - manually resolving the specs by removing the conflict
 - or updating the defaults file.
 
@@ -94,16 +101,19 @@ paths will be reported back. The user can then resolve the conflicts by either:
 The requirements for union of multiple specs are still being determined. 
 
 #### Overlay
-Overlay takes spec A along with an overlay file O (sample here LINK) to modify spec A. O is a spec fragment
+Overlay takes spec A along with a defaults file D ([sample](library/src/test/resources/metadata.yaml)) to modify spec A. D is a spec fragment
 which will be placed "on top" of spec A. 
-In the case of a collision, the overlay file takes priority. 
-An overlay operation is a specialized Union operation between A and O where O will always take priority.
+In the case of a collision, the defaults file takes priority. 
+An overlay operation is a specialized Union operation between A and D where D will always take priority.
 Therefore, Overlay operations will not have conflicts. 
 
 #### Filter
 Filtering takes spec A along with a filter file F to create a new spec B which contains a subset
 of features from A according to F. A filter file contains a list of Filter Criteria Objects, discussed below.
 Only the component references from A which are relevant to B will be included.
+
+Below is a list of properties which can be added to a Filter Criteria Object. A filter file F is a list of
+Filter Criteria Objects. For examples of F, please see the JSON files in the [filtering tests resources directory](library/src/test/resources/filtering)
 
 - **FILTER BY TAGS**. The user can achieve fine-grained filtering functionality extremely
 easily by just adding specific tags to the spec. For example, the user could mark
@@ -125,10 +135,7 @@ filtering.
 will be included. Future work includes the ability to provide an “exclude” option to filter criteria, which will exclude
 paths matching the criteria in the resultant spec.
 
-Users can provide a list of objects which contain a path, an operation, or both.
-These paths and operations will be filtered on.
-
-In addition to Filter Criteria, there will also be other filtering “options” or “parameters”. Similar
+In addition to a filter file, users can also specify other filtering “options” or “parameters”. Similar
 to the union operation, the API product which is represented by the result of a filter operation is
 quite different from the spec which was used to filter. Therefore, a useful option will be to
 provide metadata about the resultant spec.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Spec Math
 ## Overview
-Spec Math is a platform for performing operations on OpenAPI specifications. [OpenAPI](https://github.com/OAI/OpenAPI-Specification) is the industry-standard
+Spec Math is a platform for performing operations on OpenAPI specifications. 
+[OpenAPI](https://github.com/OAI/OpenAPI-Specification) is the industry-standard
 format for machine-readable REST API descriptions.
 
 ## About this document
-This document contains an overview about Spec Math and this repository. For more specific documentation 
+This document contains an overview about Spec Math and this repository. One of the goals of this document
+is to provide descriptions of Spec Math which, along with the [Java implementation in this repo](library)
+ For more specific documentation 
 and installation instructions, please look at the respective folder in the directory structure
 described below.
 


### PR DESCRIPTION
This is the README that users will see when they first arrive at the repository.

There were a few options I had in mind after a discussion with others. I feel that the root level README is a good place to give a use case to show a reason people might want to use Spec Math, and also describe the operations in detail so that they can determine if it might be useful to them (and also if they want to implement it in their own language by referencing this document and the [Java implementation](library). The [library](library) level README will likely contain specific usage examples of the API and installation instructions, etc in a later PR.

Please let me know if you have any feedback on this!