### PR TITLE
[Union with multiple specs step 2] Library supports union with multiple specs -- implement at the upper level

### DIFF
--- a/library/src/main/java/org/specmath/library/SpecMath.java
+++ b/library/src/main/java/org/specmath/library/SpecMath.java
@@ -96,6 +96,21 @@ public class SpecMath {
     return SpecTreeToYamlStringConverter.convertSpecTreeToYamlString(unionResultMap);
   }
 
+  /**
+   * Performs the union operation on a list of specs represented as YAML strings.
+   *
+   * <p>This operation will attempt to combine a list of specs represented as YAML strings using the logic
+   * provided in the SpecTreeUnionizer class. Since no special options are provided, it will attempt
+   * the union and if any conflicts are found a {@code org.specmath.library.UnionConflictException}
+   * will be thrown.
+   *
+   * @param specsToMerge a list of OpenAPI specifications represented as YAML strings to merge
+   * @return the result of the union on spec1 and spec2, as a YAML string.
+   * @throws IOException if there was a parsing issue in reading conflictResolutions
+   * @throws UnionConflictException if there was a conflict in the union process, i.e. when two
+   *     keypaths have the same value.
+   * @throws UnexpectedTypeException an unexpected type was met during the union
+   */
   public static String union(List<String> specsToMerge)
       throws UnionConflictException, UnexpectedTypeException, IOException {
     UnionOptions params = UnionOptions.builder().build();
@@ -103,6 +118,23 @@ public class SpecMath {
     return union(specsToMerge, params);
   }
 
+  /**
+   * Performs the union operation on a list of specs represented as YAML strings with {@code
+   * org.specmath.library.UnionOptions}.
+   *
+   * <p>If {@code org.specmath.library.UnionOptions} are provided, then it will apply the options as
+   * is appropriate based on the logic in the {@code SpecTreeUnionizer} class. If {@code
+   * org.specmath.library.UnionOptions} cannot resolve the conflict then a {@code
+   * org.specmath.library.UnionConflictException} will be thrown.
+   *
+   * @param specsToMerge a list of OpenAPI specifications represented as YAML strings to merge
+   * @param unionOptions a set of special options which can be applied during the union
+   * @return the result of the union on spec1 and spec2, as a YAML string
+   * @throws IOException if there was a parsing issue in reading conflictResolutions
+   * @throws UnionConflictException if there was a conflict in the union process, i.e. when two
+   *     keypaths have the same value
+   * @throws UnexpectedTypeException an unexpected type was met during the union
+   */
   public static String union(List<String> specsToMerge, UnionOptions unionOptions)
       throws IOException, UnionConflictException, UnexpectedTypeException {
     LinkedHashMap<String, Object> defaults =

--- a/library/src/main/java/org/specmath/library/SpecMath.java
+++ b/library/src/main/java/org/specmath/library/SpecMath.java
@@ -96,6 +96,41 @@ public class SpecMath {
     return SpecTreeToYamlStringConverter.convertSpecTreeToYamlString(unionResultMap);
   }
 
+  public static String union(List<String> specsToMerge)
+      throws UnionConflictException, UnexpectedTypeException, IOException {
+    UnionOptions params = UnionOptions.builder().build();
+
+    return union(specsToMerge, params);
+  }
+
+  public static String union(List<String> specsToMerge, UnionOptions unionOptions)
+      throws IOException, UnionConflictException, UnexpectedTypeException {
+    LinkedHashMap<String, Object> defaults =
+        YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(unionOptions.defaults());
+
+    var specTreesToMerge = new ArrayList<LinkedHashMap<String, Object>>();
+
+    for (String spec: specsToMerge){
+      specTreesToMerge.add(YamlStringToSpecTreeConverter.convertYamlStringToSpecTree(spec));
+    }
+
+    var conflictStringToConflictMapConverter = new ConflictStringToConflictMapConverter();
+    HashMap<String, Object> conflictResolutionsMap =
+        conflictStringToConflictMapConverter.convertConflictResolutionsStringToConflictMap(
+            unionOptions.conflictResolutions());
+
+    UnionizerUnionParams unionizerUnionParams =
+        UnionizerUnionParams.builder()
+            .defaults(defaults)
+            .conflictResolutions(conflictResolutionsMap)
+            .build();
+
+    LinkedHashMap<String, Object> unionResultMap =
+        SpecTreesUnionizer.union(specTreesToMerge, unionizerUnionParams);
+
+    return SpecTreeToYamlStringConverter.convertSpecTreeToYamlString(unionResultMap);
+  }
+
   /**
    * Performs the filter operation on a spec represented as a string using the {@code
    * filterCriteriaList}

--- a/library/src/test/java/org/specmath/library/SpecMathTest.java
+++ b/library/src/test/java/org/specmath/library/SpecMathTest.java
@@ -51,6 +51,7 @@ class SpecMathTest {
     UnionOptions unionOptions =
         UnionOptions.builder().defaults(defaults).conflictResolutions(conflictResolutions).build();
     String actual = SpecMath.union(spec1String, spec2String, unionOptions);
+    
     String expected =
         Files.readString(Path.of("src/test/resources/conflictsMergedWithDefaults.yaml"));
 
@@ -66,16 +67,13 @@ class SpecMathTest {
         assertThrows(UnionConflictException.class, () -> SpecMath.union(spec1String, spec2String));
 
     ArrayList<Conflict> expectedConflicts = new ArrayList<>();
-
     expectedConflicts.add(
-        new Conflict(
-            "[info, title]",
-            Arrays.asList("The Best Petstore Marketing Team API", "The Best Petstore Billing Team API")));
+        new Conflict("[info, title]", "The Best Petstore Marketing Team API", "The Best Petstore Billing Team API"));
     expectedConflicts.add(
         new Conflict(
             "[info, description]",
-            Arrays.asList(
-                "An API for The Best Petstore's marketing team", "An API for The Best Petstore's billing team")));
+            "An API for The Best Petstore's marketing team",
+            "An API for The Best Petstore's billing team"));
 
     assertThat(e.getConflicts()).isEqualTo(expectedConflicts);
   }

--- a/library/src/test/java/org/specmath/library/SpecMathTest.java
+++ b/library/src/test/java/org/specmath/library/SpecMathTest.java
@@ -51,7 +51,6 @@ class SpecMathTest {
     UnionOptions unionOptions =
         UnionOptions.builder().defaults(defaults).conflictResolutions(conflictResolutions).build();
     String actual = SpecMath.union(spec1String, spec2String, unionOptions);
-    
     String expected =
         Files.readString(Path.of("src/test/resources/conflictsMergedWithDefaults.yaml"));
 


### PR DESCRIPTION
NOTE: this PR is part of a series of upcoming PRs and as such, some code will be dependent on code in other branches. Breaking up into multiple PRs was done for reviewer ease.

This PR is for union with multiple specs implemented at the upper-level classes (user interface). This PR is dependent on code in step 1: https://github.com/googleinterns/spec-math/pull/33

- [x] SpecMath can now perform union on a list of OpenAPI specifications represented as YAML strings.
- [x] 100% test coverage for the new feature, which provides example usages of union with multiple specs
- [x] Union with multiple specs supports the same special options as union with two specs, i.e. defaults file and conflictResolutions, provided through the use of UnionOptions builder. 
- [x] please see step 1 https://github.com/googleinterns/spec-math/pull/33 for lower level implementation details including how conflicts are handled.
