### PR TITLE
Create README for Spec Math CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -3,11 +3,11 @@
 A command line interface which exposes some operations from the Spec Math Library.
 
 As a prerequisite, please read about Spec Math and the Spec Math operations [here](https://github.com/googleinterns/spec-math#spec-math)
-or [here](https://github.com/googleinterns/spec-math/tree/master/library).
+and [here](https://github.com/googleinterns/spec-math/tree/master/library).
 
 ## Getting Up and Running
 
-### For Unix Based Operating Systems
+### For Unix Based Operating System
 
 First, navigate to the [cli folder](.) in your terminal. Then run the following commands:
 
@@ -16,7 +16,7 @@ mvn clean install compile
 mvn package appassembler:assemble
 ```
 
-After doing so, the binary will be located at
+After doing so, the binary for the entrypoint to the Spec Math CLI will be located at
 /target/appassembler/bin/specmath in the [cli folder](.). You can run it with the help command like so:
 
 `sh /target/appassembler/bin/specmath --help`
@@ -41,7 +41,7 @@ Each of the Spec Math operations have their own subcommands with their own optio
 - `specmath filter`
 - `specmath overlay`
 
-To get help for each of these subcommands, use the `-h` or `--help` flag to learn more, (e.g. `specmath union -h`).
+To get help for each of these subcommands, use the `-h` or `--help` flag to learn more (e.g. `specmath union -h`).
 
 ## Running tests
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,7 @@ and [here](https://github.com/googleinterns/spec-math/tree/master/library).
 
 ## Getting Up and Running
 
-### For Unix Based Operating System
+### For Unix Based Operating Systems
 
 First, navigate to the [cli folder](.) in your terminal. Then run the following commands:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,9 @@
 # Spec Math CLI
 
-A command line interface which exposes some operations from the Spec Math Library
+A command line interface which exposes some operations from the Spec Math Library.
+
+As a prerequisite, please read about Spec Math and the Spec Math operations [here](https://github.com/googleinterns/spec-math#spec-math)
+or [here](https://github.com/googleinterns/spec-math/tree/master/library).
 
 ## Getting Up and Running
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,45 @@
+# Spec Math CLI
+
+A command line interface which exposes some operations from the Spec Math Library
+
+## Getting Up and Running
+
+### For Unix Based Operating Systems
+
+First, navigate to the [cli folder](.) in your terminal. Then run the following commands:
+
+```
+mvn clean install compile
+mvn package appassembler:assemble
+```
+
+After doing so, the binary will be located at
+/target/appassembler/bin/specmath in the [cli folder](.). You can run it with the help command like so:
+
+`sh /target/appassembler/bin/specmath --help`
+
+or
+
+`./target/appassembler/bin/specmath --help`
+
+you can also create an alias with the absolute path to the binary for ease of use
+
+`alias specmath="./FULL_PATH_TO_BINARY"`
+
+and add the above line to the end of your ~/.bashrc file so that you do not need
+to recreate the alias each time you open your command line. 
+
+### Usage
+
+Assuming you have set the alias as described above, the main command is `specmath`. To get help, run `specmath -h`. 
+Each of the Spec Math operations have their own subcommands with their own options and flags: 
+
+- `specmath union`
+- `specmath filter`
+- `specmath overlay`
+
+To get help for each of these subcommands, use the `-h` or `--help` flag to learn more, (e.g. `specmath union -h`).
+
+## Running tests
+
+Run `mvn test` to execute all of the tests.

--- a/cli/README.md
+++ b/cli/README.md
@@ -42,6 +42,8 @@ Each of the Spec Math operations have their own subcommands with their own optio
 - `specmath overlay`
 
 To get help for each of these subcommands, use the `-h` or `--help` flag to learn more (e.g. `specmath union -h`).
+Also, as a prerequisite, please read about Spec Math and the Spec Math operations [here](https://github.com/googleinterns/spec-math#spec-math)
+and [here](https://github.com/googleinterns/spec-math/tree/master/library).
 
 ## Running tests
 

--- a/cli/src/main/java/FilterCommand.java
+++ b/cli/src/main/java/FilterCommand.java
@@ -12,7 +12,7 @@ import picocli.CommandLine.Parameters;
 
 @Command(
     name = "filter",
-    description = "Perform the filter operation.",
+    description = "Perform the filter operation",
     version = "1.0",
     mixinStandardHelpOptions = true)
 class FilterCommand implements Callable<Integer> {

--- a/cli/src/main/java/OverlayCommand.java
+++ b/cli/src/main/java/OverlayCommand.java
@@ -10,7 +10,7 @@ import picocli.CommandLine.Parameters;
 
 @Command(
     name = "overlay",
-    description = "Perform the overlay operation.",
+    description = "Perform the overlay operation",
     version = "1.0",
     mixinStandardHelpOptions = true)
 class OverlayCommand implements Callable<Integer> {

--- a/cli/src/main/java/SpecMath.java
+++ b/cli/src/main/java/SpecMath.java
@@ -11,7 +11,7 @@ import picocli.CommandLine.Command;
     mixinStandardHelpOptions = true,
     name = "specmath",
     version = "1.0",
-    description = "Perform operations on OpenAPI Specifications")
+    description = "Perform Spec Math operations on OpenAPI Specifications. For more information please see the README.")
 public class SpecMath implements Callable<Integer> {
   public static void main(String[] args) {
     Integer exitCode = new CommandLine(new SpecMath()).execute(args);

--- a/cli/src/main/java/UnionCommand.java
+++ b/cli/src/main/java/UnionCommand.java
@@ -97,17 +97,17 @@ class UnionCommand implements Callable<Integer> {
 
     System.out.println("To resolve the conflicts you have three choices:");
     System.out.printf(
-        "1: Automatically resolving the conflicts by updating the \"resolvedValue\" property in %s"
+        "1: Updating the \"resolvedValue\" property in %s"
             + " with your desired option, and then passing that file into the union as an"
             + " additional parameter using the -c flag\n\n",
         conflictsFilename);
     System.out.printf(
-        "2: Manually resolve the conflicts by looking at %s and changing the input YAML files\n\n",
+        "2: Looking at %s and manually updating the input YAML files\n\n",
         conflictsFilename);
     System.out.printf(
-        "3: Resolve the conflicts by updating/creating a defaults file with "
-            + "overrides for the conflicting keypaths in %s, and pass in the new defaults file"
-            + " into the union as an additional parameter using the -d flags\n\n",
+        "3: Updating/creating a defaults file with "
+            + "overrides for the conflicting keypaths in %s, and passing in the new defaults file"
+            + " into the union as an additional parameter using the -d flag\n\n",
         conflictsFilename);
   }
 

--- a/cli/src/main/java/UnionCommand.java
+++ b/cli/src/main/java/UnionCommand.java
@@ -16,7 +16,7 @@ import picocli.CommandLine.Parameters;
 
 @Command(
     name = "union",
-    description = "Perform the union operation.",
+    description = "Perform the union operation",
     version = "1.0",
     mixinStandardHelpOptions = true)
 class UnionCommand implements Callable<Integer> {

--- a/cli/src/test/resources/expectedOutputUnionConflict.txt
+++ b/cli/src/test/resources/expectedOutputUnionConflict.txt
@@ -3,9 +3,9 @@ There were conflicts in the union process
 Please see the file src/test/resources/fakeFileName.yaml_CONFLICTS for more information
 
 To resolve the conflicts you have three choices:
-1: Automatically resolving the conflicts by updating the "resolvedValue" property in src/test/resources/fakeFileName.yaml_CONFLICTS with your desired option, and then passing that file into the union as an additional parameter using the -c flag
+1: Updating the "resolvedValue" property in src/test/resources/fakeFileName.yaml_CONFLICTS with your desired option, and then passing that file into the union as an additional parameter using the -c flag
 
-2: Manually resolve the conflicts by looking at src/test/resources/fakeFileName.yaml_CONFLICTS and changing the input YAML files
+2: Looking at src/test/resources/fakeFileName.yaml_CONFLICTS and manually updating the input YAML files
 
-3: Resolve the conflicts by updating/creating a defaults file with overrides for the conflicting keypaths in src/test/resources/fakeFileName.yaml_CONFLICTS, and pass in the new defaults file into the union as an additional parameter using the -d flags
+3: Updating/creating a defaults file with overrides for the conflicting keypaths in src/test/resources/fakeFileName.yaml_CONFLICTS, and passing in the new defaults file into the union as an additional parameter using the -d flag
 


### PR DESCRIPTION
This is the README for the Spec Math CLI which was created in https://github.com/googleinterns/spec-math/pull/39. It contains some building and usage instructions, along with the help dialogs which are provided in the CLI itself. You can view the README in rendered markdown more easily here: https://github.com/rkhaled98/spec-math/tree/readmeCli/cli

When testing this CLI, please keep in mind that there's a lot of room for cool future improvements for such as interactive conflict resolution! :smile: Also, feel free to ignore files other than the README in this PR, which were minor changes and mostly related to punctuation, formatting, and help dialogs.

