### PR TITLE
temporary instructions for the CLI before the library is uploaded to maven

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -9,10 +9,21 @@ and [here](https://github.com/googleinterns/spec-math/tree/master/library).
 
 ### For Unix Based Operating Systems
 
-First, navigate to the [cli folder](.) in your terminal. Then run the following commands:
+As the Spec Math Library has not yet been uploaded to Maven, you will need to first need to navigate
+to the [library folder](../library) in your terminal. Then run the following commands:
 
 ```
-mvn clean install compile
+mvn clean
+mvn install
+mvn compile
+```
+
+Then, navigate to the [cli folder](.) in your terminal and run these commands:
+
+```
+mvn clean
+mvn install
+mvn compile
 mvn package appassembler:assemble
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,21 +9,23 @@ and [here](https://github.com/googleinterns/spec-math/tree/master/library).
 
 ### For Unix Based Operating Systems
 
-As the Spec Math Library has not yet been uploaded to Maven, you will need to first need to navigate
+You should first clone the repository:
+
+```
+git clone https://github.com/googleinterns/spec-math.git
+```
+
+As the Spec Math Library has not yet been uploaded to Maven, you will need to navigate
 to the [library folder](../library) in your terminal. Then run the following commands:
 
 ```
-mvn clean
-mvn install
-mvn compile
+mvn clean install
 ```
 
 Then, navigate to the [cli folder](.) in your terminal and run these commands:
 
 ```
-mvn clean
-mvn install
-mvn compile
+mvn clean install
 mvn package appassembler:assemble
 ```
 


### PR DESCRIPTION
As discussed with @ssvaidyanathan, we should probably add some temporary instructions to the CLI README until the library is added to Maven. The additional instructions simply involve installing the library before the cli.
 